### PR TITLE
docs: fix README links, add eval/hooks/integration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ Requires Python 3.11+.
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)
+- [End-to-End Integration Guide](docs/integration-guide.md) ← start here for real agent setup
 - [Writing Evals](docs/eval-authoring-guide.md)
+- [Hook Scripts](docs/hooks-guide.md)
 - [CI/CD Integration](docs/ci-integration.md)
 - [Configuration Reference](docs/configuration-reference.md)
-- [Hook Scripts](docs/hooks-guide.md)
 
 ## What skill-gate Does NOT Do
 
-- Does **not** replace [Anthropic's skill-creator](https://docs.anthropic.com) for writing evals
+- Does **not** replace [Anthropic's skill-creator](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md) for writing skills
 - Does **not** host or serve skills — skills live in your repo
 - Does **not** modify skills — it reports issues, authors fix them
 - Does **not** require a database or server — the catalog is a YAML file in your repo

--- a/docs/eval-authoring-guide.md
+++ b/docs/eval-authoring-guide.md
@@ -1,0 +1,143 @@
+# Writing Evals for skill-gate
+
+Evals are prompt/response test cases that verify your skill behaves correctly when loaded into a real agent. `skill-gate test` runs them against any OpenAI Responses API-compatible endpoint.
+
+---
+
+## Directory structure
+
+Every skill that supports `skill-gate test` needs an `evals/` directory:
+
+```
+my-skill/
+├── SKILL.md
+└── evals/
+    ├── config.yaml          # test definitions
+    └── prompts/
+        ├── basic.md         # one file per test case
+        ├── edge-case.md
+        └── out-of-scope.md
+```
+
+---
+
+## config.yaml format
+
+```yaml
+tests:
+  - name: basic-usage
+    prompt_file: prompts/basic.md
+    expect:
+      contains: ["diagnosed", "latency"]        # all must appear in response
+      not_contains: ["I cannot help", "error"]  # none may appear
+      max_latency_ms: 3000                       # round-trip must be under 3s
+      skill_triggered: my-skill                 # agent must call this tool
+
+  - name: edge-case
+    prompt_file: prompts/edge-case.md
+    expect:
+      contains: ["no active connections found"]
+
+  - name: out-of-scope
+    prompt_file: prompts/out-of-scope.md
+    expect:
+      not_contains: ["traceroute", "packet loss"]
+      skill_not_triggered: my-skill             # skill must NOT be called
+```
+
+---
+
+## Expect checks reference
+
+| Field | Type | What it checks |
+|---|---|---|
+| `contains` | `list[str]` | All strings must appear somewhere in the response text |
+| `not_contains` | `list[str]` | None of these strings may appear in the response text |
+| `min_length` | `int` | Response text must be at least N characters |
+| `max_latency_ms` | `int` | Round-trip time must not exceed N milliseconds |
+| `skill_triggered` | `str` | A tool call with this exact name must appear in the response |
+| `skill_not_triggered` | `str` | A tool call with this name must NOT appear |
+
+All checks in an `expect` block must pass for the test to pass. A single failed check fails the test.
+
+---
+
+## Writing good prompts
+
+Each `prompt_file` is plain text sent as the `input` field of a Responses API request.
+
+**For positive tests (skill should trigger):**
+```markdown
+My AWS Direct Connect link keeps dropping packets intermittently.
+Can you help diagnose what's causing the connectivity issue?
+```
+
+Write prompts that a real user would send. Avoid prompts that are so specific they only work with your exact implementation — test the intent, not the exact phrasing.
+
+**For negative tests (skill should NOT trigger):**
+```markdown
+I need help setting up an Azure VPN gateway.
+```
+
+Out-of-scope prompts verify your skill doesn't over-trigger. Every skill should have at least one.
+
+**For edge cases:**
+```markdown
+I'm seeing 0.01% packet loss. Is that significant?
+```
+
+Edge cases test boundary conditions — low-signal inputs, ambiguous requests, inputs that are technically in scope but at the margins.
+
+---
+
+## Recommended test coverage
+
+| Test type | Min count | Purpose |
+|---|---|---|
+| Positive (skill triggers) | 2–3 | Core use cases actually work |
+| Negative (skill doesn't trigger) | 1–2 | Skill doesn't over-trigger |
+| Edge case | 1–2 | Boundary conditions handled |
+
+A skill with only positive tests will pass `skill-gate test` but may cause conflicts with other skills in production. Always include at least one out-of-scope prompt.
+
+---
+
+## Running evals
+
+```bash
+# Against a local agent
+skill-gate test ./skills/my-skill/ \
+  --endpoint http://localhost:8000 \
+  --model gpt-4.1
+
+# Against a staging agent with API key
+skill-gate test ./skills/my-skill/ \
+  --endpoint https://staging-agent.example.com \
+  --api-key $AGENT_API_KEY \
+  --model gpt-4.1 \
+  --format json
+
+# As part of the full gate
+skill-gate check ./skills/my-skill/ \
+  --against ./skills/ \
+  --endpoint http://localhost:8000
+```
+
+---
+
+## Debugging failing evals
+
+Use `--format json` to get full response details:
+
+```bash
+skill-gate test ./skills/my-skill/ --endpoint http://localhost:8000 --format json | jq '.result.results[] | select(.passed == false)'
+```
+
+This shows the exact response text, tool calls, and which checks failed for each failing test.
+
+---
+
+## See also
+
+- [Hook Scripts](hooks-guide.md) — set up agent state before evals run
+- [CI Integration](ci-integration.md) — run evals in GitHub Actions

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -1,0 +1,152 @@
+# Hook Scripts
+
+Hook scripts let you prepare your agent before evals run and clean up after. Common uses: loading a skill into a running agent, resetting agent state, restarting a service.
+
+---
+
+## When you need hooks
+
+`skill-gate test` sends prompts directly to your agent endpoint — it does not deploy the skill for you. If your agent needs to load the skill before it can use it, you need a pre-test hook to do that deployment.
+
+If your agent loads skills at startup from a directory, hooks are the way to inject the skill under test before evals run.
+
+---
+
+## Configuration
+
+```yaml
+# skill-gate.yaml
+test:
+  endpoint: http://localhost:8000
+  model: gpt-4.1
+  injection:
+    pre_test_hook: hooks/deploy-skill.sh    # runs before evals
+    post_test_hook: hooks/remove-skill.sh   # always runs after evals (even on failure)
+  reload_timeout_seconds: 30               # max wait for agent to become healthy after hook
+```
+
+---
+
+## Hook contract
+
+| Property | Detail |
+|---|---|
+| Arguments | `$1` = skill path (absolute), `$2` = agent endpoint URL |
+| Exit code | `0` = success, non-zero = abort test run |
+| Stdout/stderr | Captured and shown on hook failure |
+| Post-hook | Always runs — even if evals fail or pre-hook fails (cleanup must be safe) |
+
+---
+
+## Example: directory copy
+
+The simplest approach — copy the skill into the agent's skills directory, then wait for it to reload:
+
+```bash
+#!/usr/bin/env bash
+# hooks/deploy-skill.sh
+set -euo pipefail
+
+SKILL_PATH="$1"
+AGENT_SKILLS_DIR="${AGENT_SKILLS_DIR:-/app/skills}"
+
+cp -r "$SKILL_PATH" "$AGENT_SKILLS_DIR/"
+echo "Deployed $(basename "$SKILL_PATH") to $AGENT_SKILLS_DIR"
+```
+
+```bash
+#!/usr/bin/env bash
+# hooks/remove-skill.sh
+set -euo pipefail
+
+SKILL_PATH="$1"
+AGENT_SKILLS_DIR="${AGENT_SKILLS_DIR:-/app/skills}"
+
+rm -rf "$AGENT_SKILLS_DIR/$(basename "$SKILL_PATH")"
+echo "Removed $(basename "$SKILL_PATH") from $AGENT_SKILLS_DIR"
+```
+
+---
+
+## Example: HTTP API injection
+
+If your agent exposes an API to load/unload skills dynamically:
+
+```bash
+#!/usr/bin/env bash
+# hooks/deploy-skill.sh
+set -euo pipefail
+
+SKILL_PATH="$1"
+ENDPOINT="$2"
+SKILL_NAME=$(basename "$SKILL_PATH")
+
+curl -sf -X POST "$ENDPOINT/admin/skills/load" \
+  -H "Content-Type: application/json" \
+  -d "{\"path\": \"$SKILL_PATH\"}" \
+  || { echo "Failed to load skill via API"; exit 1; }
+
+echo "Loaded $SKILL_NAME via agent API"
+```
+
+---
+
+## Example: Docker container
+
+If your agent runs in Docker and you need to copy the skill in and restart:
+
+```bash
+#!/usr/bin/env bash
+# hooks/deploy-skill.sh
+set -euo pipefail
+
+SKILL_PATH="$1"
+CONTAINER="${AGENT_CONTAINER:-my-agent}"
+
+docker cp "$SKILL_PATH" "$CONTAINER:/app/skills/"
+docker restart "$CONTAINER"
+echo "Restarted $CONTAINER with $(basename "$SKILL_PATH")"
+```
+
+---
+
+## Health check after hook
+
+After the pre-test hook runs, skill-gate polls `GET {endpoint}/health` until it returns 200 or `reload_timeout_seconds` is exceeded. Your agent should expose a `/health` endpoint that returns `{"status": "ok"}` when ready.
+
+```python
+# FastAPI example
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+```
+
+---
+
+## Hook failure behavior
+
+| Scenario | What happens |
+|---|---|
+| Pre-hook exits non-zero | Test run aborted, post-hook still runs, exit code 5 |
+| Agent doesn't become healthy within timeout | Test run aborted, post-hook still runs, exit code 6 |
+| Eval test fails | Post-hook still runs, exit code 1 |
+| Post-hook exits non-zero | Logged as warning, exit code from evals is preserved |
+
+---
+
+## Debugging hooks
+
+Run hooks manually to verify they work before wiring into skill-gate:
+
+```bash
+chmod +x hooks/deploy-skill.sh
+./hooks/deploy-skill.sh ./skills/my-skill http://localhost:8000
+echo "exit: $?"
+```
+
+---
+
+## See also
+
+- [Writing Evals](eval-authoring-guide.md)
+- [CI Integration](ci-integration.md) — hooks in GitHub Actions pipelines

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1,0 +1,335 @@
+# End-to-End Integration Guide
+
+How to integrate skill-gate into an existing skills repo and test against a real OpenAI Responses API-compatible agent.
+
+---
+
+## Overview
+
+```
+Your skills repo
+├── skills/
+│   ├── my-skill/
+│   │   ├── SKILL.md
+│   │   └── evals/
+│   ├── another-skill/
+│   └── skill-catalog.yaml     ← managed by skill-gate catalog
+├── skill-gate.yaml            ← skill-gate config
+└── .github/workflows/
+    ├── skill-gate-ci.yml      ← PR gate (validate+secure+conflict+test)
+    └── skill-gate-monitor.yml ← weekly health check
+```
+
+---
+
+## Step 1: Initialize skill-gate in your repo
+
+```bash
+pip install skill-gate
+cd your-skills-repo
+skill-gate init
+```
+
+This creates `skill-gate.yaml` with commented defaults. Edit it:
+
+```yaml
+# skill-gate.yaml
+skills_dir: ./skills/
+catalog_path: ./skill-catalog.yaml
+
+validate:
+  require_evals: true          # block if no evals/ directory
+
+test:
+  endpoint: ${AGENT_API_ENDPOINT}   # your agent's base URL
+  api_key: ${AGENT_API_KEY}
+  model: gpt-4.1                    # model your agent uses
+  reload_timeout_seconds: 30
+
+monitor:
+  stale_threshold_days: 180
+  degrade_after_days: 7
+  notify:
+    slack_webhook: ${SLACK_WEBHOOK_URL}   # optional
+```
+
+---
+
+## Step 2: Add evals to your skills
+
+Each skill needs an `evals/` directory for `skill-gate test` to work. See [Writing Evals](eval-authoring-guide.md) for full details.
+
+Minimum structure:
+
+```
+skills/my-skill/
+├── SKILL.md
+└── evals/
+    ├── config.yaml
+    └── prompts/
+        ├── basic.md        # positive test — skill should trigger
+        └── out-of-scope.md # negative test — skill should NOT trigger
+```
+
+`evals/config.yaml`:
+```yaml
+tests:
+  - name: basic-usage
+    prompt_file: prompts/basic.md
+    expect:
+      contains: ["diagnosed"]
+      skill_triggered: my-skill
+
+  - name: out-of-scope
+    prompt_file: prompts/out-of-scope.md
+    expect:
+      skill_not_triggered: my-skill
+```
+
+---
+
+## Step 3: What your agent needs to expose
+
+skill-gate communicates with your agent via the **OpenAI Responses API** format. Your agent needs two endpoints:
+
+### `GET /health` → 200 OK
+```json
+{"status": "ok"}
+```
+Used to confirm the agent is ready after skill injection.
+
+### `POST /v1/responses`
+Request format (OpenAI Responses API):
+```json
+{
+  "model": "gpt-4.1",
+  "input": "My AWS connection keeps dropping packets. Can you help diagnose?"
+}
+```
+
+Response format skill-gate parses:
+```json
+{
+  "output": [
+    {
+      "type": "tool_call",
+      "name": "my-skill"
+    },
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "I'll help diagnose the connectivity issue..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+skill-gate extracts:
+- **Tool calls** from `output[].type == "tool_call"` → `output[].name`
+- **Response text** from `output[].type == "message"` → `output[].content[].text`
+
+Any OpenAI-compatible agent (OpenAI Assistants, custom FastAPI wrapper, LangChain agent with Responses API adapter) works as-is.
+
+---
+
+## Step 4: Run locally first
+
+```bash
+# Export your agent config
+export AGENT_API_ENDPOINT=http://localhost:8000
+export AGENT_API_KEY=your-key   # omit if no auth
+
+# 1. Validate skill format
+skill-gate validate skills/my-skill/
+
+# 2. Scan for security issues
+skill-gate secure skills/my-skill/
+
+# 3. Check for conflicts with other skills
+skill-gate conflict skills/my-skill/ --against skills/
+
+# 4. Run evals against your agent
+skill-gate test skills/my-skill/ \
+  --endpoint $AGENT_API_ENDPOINT \
+  --api-key $AGENT_API_KEY \
+  --model gpt-4.1
+
+# 5. Run everything in one command
+skill-gate check skills/my-skill/ \
+  --against skills/ \
+  --endpoint $AGENT_API_ENDPOINT
+```
+
+All commands exit 0 on pass, 1 on failure — scriptable in any CI system.
+
+---
+
+## Step 5: Register skills in the catalog
+
+After a skill passes all checks, register it:
+
+```bash
+skill-gate catalog register skills/my-skill/ --catalog skill-catalog.yaml
+```
+
+This creates/updates `skill-catalog.yaml` with the skill's metadata, quality score, and stage (`staging` by default).
+
+```bash
+# View catalog
+skill-gate catalog list
+
+# Promote to production (manual, after your review process)
+# Edit skill-catalog.yaml: change stage: staging → stage: production
+```
+
+Commit `skill-catalog.yaml` to your repo — it's the source of truth for deployed skills.
+
+---
+
+## Step 6: Set up CI (GitHub Actions)
+
+Create `.github/workflows/skill-gate-ci.yml`:
+
+```yaml
+name: skill-gate CI
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+
+jobs:
+  skill-gate:
+    runs-on: ubuntu-latest
+    env:
+      AGENT_API_ENDPOINT: ${{ secrets.AGENT_API_ENDPOINT }}
+      AGENT_API_KEY: ${{ secrets.AGENT_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install skill-gate
+        run: pip install skill-gate
+
+      - name: Detect changed skill
+        id: changed
+        run: |
+          SKILL=$(git diff --name-only origin/main...HEAD | grep '^skills/' | head -1 | cut -d/ -f1-2)
+          echo "skill=$SKILL" >> $GITHUB_OUTPUT
+
+      - name: skill-gate check
+        run: |
+          skill-gate check ${{ steps.changed.outputs.skill }} \
+            --against skills/ \
+            --endpoint $AGENT_API_ENDPOINT \
+            --format md > sg-report.md
+          cat sg-report.md
+
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('sg-report.md', 'utf8');
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '## skill-gate report\n\n' + body
+            });
+```
+
+Add secrets to your repo: `Settings → Secrets → AGENT_API_ENDPOINT`, `AGENT_API_KEY`.
+
+---
+
+## Step 7: Set up weekly monitoring
+
+Create `.github/workflows/skill-gate-monitor.yml`:
+
+```yaml
+name: skill-gate Monitor
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Monday 9am UTC
+  workflow_dispatch:
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    env:
+      AGENT_API_ENDPOINT: ${{ secrets.AGENT_API_ENDPOINT }}
+      AGENT_API_KEY: ${{ secrets.AGENT_API_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install skill-gate
+      - run: |
+          skill-gate monitor \
+            --catalog skill-catalog.yaml \
+            --endpoint $AGENT_API_ENDPOINT \
+            --format md
+```
+
+---
+
+## Step 8: Verify the Anthropic skills repo format
+
+If you're using the [Anthropic skills repo](https://github.com/anthropics/skills), skill-gate is compatible out of the box — the SKILL.md format is the same. Run from the repo root:
+
+```bash
+# Clone the skills repo
+git clone https://github.com/anthropics/skills
+cd skills
+
+pip install skill-gate
+skill-gate init
+
+# Validate an existing skill
+skill-gate validate skills/skill-creator/
+
+# Check all skills for conflicts
+for skill in skills/*/; do
+  echo "=== $skill ==="
+  skill-gate conflict "$skill" --against skills/
+done
+```
+
+---
+
+## Troubleshooting
+
+**`skill-gate test` fails: "Agent endpoint is required"**
+→ Pass `--endpoint` or set `test.endpoint` in `skill-gate.yaml`
+
+**Evals fail: response text doesn't contain expected strings**
+→ Check what your agent actually returns: `skill-gate test ... --format json | jq '.result.results[].response_text'`
+
+**Conflict score 1.0 with existing skill**
+→ Your skill description overlaps too much. Narrow the trigger: add "Use when X but NOT when Y" to the description.
+
+**Hook timeout**
+→ Increase `reload_timeout_seconds` in config, or check your agent's `/health` endpoint responds correctly after skill injection.
+
+---
+
+## See also
+
+- [Writing Evals](eval-authoring-guide.md)
+- [Hook Scripts](hooks-guide.md)
+- [CI Integration](ci-integration.md)
+- [Configuration Reference](configuration-reference.md)


### PR DESCRIPTION
Closes #18, #19, #20

## Changes

**Bug fixes:**
- #19 Fix wrong Anthropic skill-creator URL (was `docs.anthropic.com`, now correct GitHub link)
- #18 Create `docs/eval-authoring-guide.md` — full eval authoring reference with config format, expect checks, prompt writing tips, debugging
- #18 Create `docs/hooks-guide.md` — hook scripts guide with directory copy, HTTP API, Docker container examples

**New docs:**
- #20 `docs/integration-guide.md` — end-to-end guide: init → add evals → wire agent → run locally → register catalog → set up CI → set up monitoring. Covers exactly what a Responses API-compatible agent needs to expose (`GET /health`, `POST /v1/responses` format)

**README:**
- Updated Documentation section with correct links
- Integration guide promoted to top (most common first use case)