### PR TITLE
fix: rename PyPI package to agentskill-gate

### DIFF
--- a/PYPI_SETUP.md
+++ b/PYPI_SETUP.md
@@ -7,7 +7,7 @@ skill-gate uses **Trusted Publishing (OIDC)** — no API token needed. One-time 
 1. **Create the PyPI project**
    - Go to https://pypi.org/manage/account/publishing/
    - Add a new Trusted Publisher:
-     - PyPI project name: `skill-gate`
+     - PyPI project name: `agentskill-gate`
      - GitHub owner: `vaibhavtupe`
      - GitHub repo: `skill-gate`
      - Workflow filename: `publish.yml`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The quality gate for Agent Skills.**
 
-[![PyPI version](https://badge.fury.io/py/skill-gate.svg)](https://badge.fury.io/py/skill-gate)
+[![PyPI version](https://badge.fury.io/py/agentskill-gate.svg)](https://badge.fury.io/py/agentskill-gate)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
@@ -37,7 +37,7 @@ ONGOING (post-merge, scheduled):
 ## Quick Start
 
 ```bash
-pip install skill-gate
+pip install agentskill-gate
 
 # Initialize in your skills repo
 skill-gate init
@@ -59,10 +59,10 @@ skill-gate check ./skills/my-skill/ --against ./skills/
 
 ```bash
 # Core (static analysis — no agent required)
-pip install skill-gate
+pip install agentskill-gate
 
 # With embedding-based conflict detection
-pip install skill-gate[embeddings]
+pip install agentskill-gate[embeddings]
 ```
 
 Requires Python 3.11+.

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install skill-gate
-        run: pip install skill-gate
+        run: pip install agentskill-gate
 
       - name: Validate skill
         run: skill-gate validate skills/my-skill --format json
@@ -80,7 +80,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install skill-gate
-        run: pip install skill-gate
+        run: pip install agentskill-gate
 
       # Run the full pipeline in one command
       - name: skill-gate check

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,13 +3,13 @@
 ## Install
 
 ```bash
-pip install skill-gate
+pip install agentskill-gate
 ```
 
 Optional embeddings (Phase 3):
 
 ```bash
-pip install skill-gate[embeddings]
+pip install agentskill-gate[embeddings]
 ```
 
 ## Quick Start

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -25,7 +25,7 @@ Your skills repo
 ## Step 1: Initialize skill-gate in your repo
 
 ```bash
-pip install skill-gate
+pip install agentskill-gate
 cd your-skills-repo
 skill-gate init
 ```
@@ -217,7 +217,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install skill-gate
-        run: pip install skill-gate
+        run: pip install agentskill-gate
 
       - name: Detect changed skill
         id: changed
@@ -277,7 +277,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install skill-gate
+      - run: pip install agentskill-gate
       - run: |
           skill-gate monitor \
             --catalog skill-catalog.yaml \
@@ -296,7 +296,7 @@ If you're using the [Anthropic skills repo](https://github.com/anthropics/skills
 git clone https://github.com/anthropics/skills
 cd skills
 
-pip install skill-gate
+pip install agentskill-gate
 skill-gate init
 
 # Validate an existing skill

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "skill-gate"
+name = "agentskill-gate"
 version = "0.3.2"
 description = "The quality gate for Agent Skills — validate, secure, conflict-detect, and test skills across their full lifecycle"
 readme = "README.md"


### PR DESCRIPTION
Closes #22

## Problem
PyPI rejects `skill-gate` as too similar to existing package `skillgate`.

## Solution
Rename PyPI package to `agentskill-gate` (verified available).

## What changes
- `pyproject.toml`: `name = "agentskill-gate"`
- All docs + README: `pip install agentskill-gate`
- `PYPI_SETUP.md`: updated project name for Trusted Publishing config

## What stays the same
- CLI command: `skill-gate` (unchanged)
- Python import: `skill_gate` (unchanged)
- GitHub repo name: unchanged
- All functionality: unchanged

## Verified
- Build produces `agentskill_gate-0.3.2` wheel ✅
- `skill-gate --version` works from installed wheel ✅  
- 64 tests passing, 81.62% coverage ✅