### PR TITLE
fix: update repo URLs to skill-guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,5 +59,5 @@
 - PyPI package: `skill-guard` (was `agentskill-gate`)
 - CLI command: `skill-guard` (was `skill-gate`)
 - Python package: `skill_guard` (was `skill_gate`)
-- GitHub repo: `vaibhavtupe/skillguard` (was `skill-gate`)
+- GitHub repo: `vaibhavtupe/skill-guard` (was `skill-gate`)
 - All functionality unchanged — pure rename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,9 @@ dev = [
 skill-guard = "skill_guard.main:app"
 
 [project.urls]
-Homepage = "https://github.com/vaibhavtupe/skillguard"
-Repository = "https://github.com/vaibhavtupe/skillguard"
-Issues = "https://github.com/vaibhavtupe/skillguard/issues"
+Homepage = "https://github.com/vaibhavtupe/skill-guard"
+Repository = "https://github.com/vaibhavtupe/skill-guard"
+Issues = "https://github.com/vaibhavtupe/skill-guard/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["skill_guard"]


### PR DESCRIPTION
Closes #26

pyproject.toml Homepage/Repository/Issues URLs corrected from `skillguard` → `skill-guard`.