### PR TITLE
chore: OSS readiness checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report a bug in skill-guard
+labels: bug
+---
+
+## Description
+<!-- Clear description of the bug -->
+
+## Steps to reproduce
+```bash
+skill-guard <command> ...
+```
+
+## Expected behavior
+
+## Actual behavior
+
+## Environment
+- skill-guard version: <!-- `skill-guard --version` -->
+- Python version:
+- OS:
+
+## Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem / motivation
+<!-- What problem does this solve? -->
+
+## Proposed solution
+<!-- How should it work? -->
+
+## Alternatives considered
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- What does this PR do? -->
+
+Closes #<!-- issue number -->
+
+## Changes
+<!-- List key changes -->
+
+## Testing
+- [ ] Tests added/updated
+- [ ] `pytest tests/` passes locally
+- [ ] `ruff check .` passes
+- [ ] End-to-end verified (`skill-guard validate/secure/conflict`)
+
+## Notes
+<!-- Anything reviewers should know -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+- Harassment, trolling, or insulting comments
+- Publishing others' private information without permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported via [GitHub Security Advisories](https://github.com/vaibhavtupe/skill-guard/security/advisories/new). All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| 0.4.x | ✅ |
+| < 0.4 | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities via public GitHub issues.**
+
+Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/vaibhavtupe/skill-guard/security/advisories/new).
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fix (optional)
+
+You will receive a response within **48 hours** and a fix within **7 days** for critical issues.
+
+## Scope
+
+Security issues in scope:
+- Prompt injection bypass in the `secure` scanner
+- Path traversal in skill parsing
+- Command injection via hook scripts
+- Credential leakage in output/logs
+
+Out of scope:
+- Issues in optional dependencies (report upstream)
+- Denial of service via large skill files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "The quality gate for Agent Skills — validate, secure, conflict-
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"
-authors = [{ name = "Vaibhav Tupe", email = "vaibhav@example.com" }]
+authors = [{ name = "Vaibhav Tupe", email = "8600448+vaibhavtupe@users.noreply.github.com" }]
 keywords = ["agent-skills", "ai-agents", "cli", "quality-gate", "llm"]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Closes #30 #31 #32 #33 #34 #35

## Changes
- #30 Fix placeholder email → GitHub noreply address
- #31 Add `SECURITY.md` — private vulnerability reporting via GitHub Advisories
- #32 Add `.github/ISSUE_TEMPLATE/bug_report.md` + `feature_request.md` + `PULL_REQUEST_TEMPLATE.md`
- #33 Add `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)
- #34 Add `.github/dependabot.yml` — weekly pip + GitHub Actions updates
- #35 Set repo topics: agent-skills, ai-agents, cli, llm, openai, python, quality-gate, skill-guard

All tests passing ✅ | Lint clean ✅