### PR TITLE
fix(#45): correct example command syntax and README output sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,26 @@ skill-guard check ./skills/my-skill/ --against ./skills/
 
 ### Example Output
 
-```bash
-$ skill-guard validate ./skills/pdf/
-✔  SKILL.md found
-✔  Required fields present (name, description)
-✔  Description length: 156 chars (good)
-✔  No disallowed fields
-⚠  No evals/ directory found (recommended for testability)
-⚠  No scripts/ directory found
+```
+$ skill-guard validate ./skills/my-skill/
 
-Quality score: 78/100  Grade: B
+ skill-guard validate — my-skill
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Check                     ┃ Result                                           ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ skill_md_exists           │ ✅ SKILL.md found                                │
+│ valid_yaml_frontmatter    │ ✅ Valid YAML frontmatter                        │
+│ name_field_present        │ ✅ name: my-skill                                │
+│ description_field_present │ ✅ description field present                     │
+│ directory_name_matches    │ ✅ Directory name matches skill name             │
+│ description_trigger_hint  │ ✅ Description contains trigger hint ('Use when')│
+│ no_broken_body_paths      │ ✅ No broken relative paths in SKILL.md body     │
+│ evals_directory_exists    │ ⚠️ No evals/ directory found                     │
+│                           │ → Create evals/config.yaml with test cases       │
+│ metadata_has_author       │ ✅ author: my-team                               │
+│ metadata_has_version      │ ✅ version: 1.0                                  │
+└───────────────────────────┴──────────────────────────────────────────────────┘
+Score: 97/100 | Grade: A | Blockers: 0 | Warnings: 1
 ```
 
 ## Installation

--- a/examples/basic-quickstart/README.md
+++ b/examples/basic-quickstart/README.md
@@ -4,8 +4,25 @@ Minimal local workflow:
 
 ```bash
 python3 -m pip install skill-guard
+
+# Initialize config in the current project
 skill-guard init
-skill-guard validate --dir ./skills
+
+# Validate a single skill directory
+skill-guard validate ./skills/my-skill/
+
+# Check for security issues
+skill-guard secure ./skills/my-skill/
+
+# Check for conflicts with other skills
+skill-guard conflict ./skills/my-skill/ --against ./skills/
 ```
 
-This initializes config in the current project and validates skills in a local `./skills` directory.
+Each command takes a **single skill directory** (the folder that contains `SKILL.md`).
+To validate multiple skills, loop over them:
+
+```bash
+for skill_dir in ./skills/*/; do
+  skill-guard validate "$skill_dir"
+done
+```

--- a/examples/validate-anthropic-skills/run.sh
+++ b/examples/validate-anthropic-skills/run.sh
@@ -11,8 +11,17 @@ else
   git clone https://github.com/anthropics/skills "$REPO_DIR"
 fi
 
-skill-guard validate --dir "$SKILLS_DIR"
+echo "Validating each skill in $SKILLS_DIR ..."
+for skill_dir in "$SKILLS_DIR"/*/; do
+  echo ""
+  echo "── $(basename "$skill_dir") ──"
+  skill-guard validate "$skill_dir"
+done
 
 if [ "${1:-}" = "--with-conflict" ]; then
-  skill-guard conflict --dir "$SKILLS_DIR"
+  echo ""
+  echo "── Conflict detection ──"
+  for skill_dir in "$SKILLS_DIR"/*/; do
+    skill-guard conflict "$skill_dir" --against "$SKILLS_DIR"
+  done
 fi


### PR DESCRIPTION
Closes #45

Found during manual verification that examples were broken before anyone could even try them.

**Fixes:**
- `run.sh`: validate/conflict loop over each skill dir individually (command takes a single `SKILL_PATH`, not a parent dir); remove non-existent `--dir` flag
- `basic-quickstart/README.md`: correct command syntax + add multi-skill loop example
- `README.md`: replace stale `✔` example output with accurate table format matching actual CLI output

All CI checks should pass (no logic changes).