### PR TITLE
fix(#47): bump typer>=0.13.0, release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.4.3 — 2026-03-06
+
+### Bug Fixes
+
+- **Fix crash on startup with typer <0.13** — `Path | None` union type not supported by typer 0.9.x; tightened minimum to `typer>=0.13.0` (closes #47)
+- **Fix all `skill-gate` → `skill-guard` naming** throughout Python source, config, init, tests, and output headers (closes #44)
+- **Fix example command syntax** — examples used non-existent `--dir` flag; corrected to positional `SKILL_PATH` with multi-skill loop pattern (closes #45)
+- **Add `examples/` directory** — `validate-anthropic-skills/` and `basic-quickstart/` with accurate working commands (closes #42)
+- **Fix README naming** — removed stale `agentskill-guard` references; updated example output to match actual table format (closes #41)
+
+---
+
 ## v0.3.0 — 2026-03-05
 
 ### Phase 3: Monitoring + Lifecycle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skill-guard"
-version = "0.4.2"
+version = "0.4.3"
 description = "The quality gate for Agent Skills — validate, secure, conflict-detect, and test skills across their full lifecycle"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "typer>=0.12",
+    "typer>=0.13.0",
     "ruamel.yaml>=0.18",
     "scikit-learn>=1.4",
     "httpx>=0.27",


### PR DESCRIPTION
Closes #47

**Root cause:** `Path | None` union type annotation in command params crashes typer <0.13.0 with `RuntimeError: Type not yet supported: pathlib._local.Path | None`. Our constraint was `typer>=0.12` which allowed the broken range in.

**Fix:** `typer>=0.13.0` minimum + version bump to 0.4.3 + CHANGELOG with all fixes since 0.4.2.

58 unit tests passing.