### PR TITLE
docs: add Prerequisites section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,27 @@ Score: 97/100 | Grade: A | Blockers: 0 | Warnings: 1
 
 ## Installation
 
+## Prerequisites
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Python | 3.11+ | Required. 3.12 and 3.13 tested. |
+| pip | any recent | Bundled with Python |
+| typer | ≥0.13.0 | Installed automatically |
+| git | any | Required only if using `skill-guard test` or `skill-guard monitor` with a repo |
+| Agent endpoint | — | Required only for `skill-guard test` (OpenAI-compatible API) |
+
+> **Note:** `skill-guard validate`, `secure`, `conflict`, `init`, `catalog`, and `check` work fully offline — no agent or API key needed.
+
+## Installation
+
 ```bash
 # Core (static analysis — no agent required)
 pip install skill-guard
 
-# With embedding-based conflict detection
+# With embedding-based conflict detection (sentence-transformers)
 pip install skill-guard[embeddings]
 ```
-
-Requires Python 3.11+.
 
 ## Documentation
 


### PR DESCRIPTION
Makes the setup requirements explicit so users know what they need before installing.

**Adds:**
- Prerequisites table: Python 3.11+, pip, typer ≥0.13.0 (auto-installed), git (only for test/monitor), agent endpoint (only for test)
- Callout note clarifying which commands work fully offline vs which need an agent

**Why:** The crash users hit (`RuntimeError: Type not yet supported: Path | None`) was partly because there was no clear guidance on minimum typer version or Python version — just a badge and one buried line.