### PR TITLE
fix: close all 10 open issues + bump to v0.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Score: 97/100 | Grade: A | Blockers: 0 | Warnings: 1
 # Core (static analysis — no agent required)
 pip install skill-guard
 
-# With embedding-based conflict detection (sentence-transformers)
+# Optional future extras for planned embedding-based conflict detection
 pip install skill-guard[embeddings]
 ```
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -22,21 +22,26 @@ validate:
 secure:
   block_on: [critical, high]
   allow_external_urls_in_scripts: false
-  use_snyk_scan: false
+  use_snyk_scan: false  # reserved for future integration
   allow_list:
     - id: EXEC-001
       reason: "Standard install pattern"
       file: scripts/setup.sh
 
 conflict:
-  method: tfidf
+  method: tfidf  # the only supported method today
   high_overlap_threshold: 0.75
   medium_overlap_threshold: 0.55
   block_on_high_overlap: true
 
+monitor:
+  stale_threshold_days: 180
+  degrade_after_failures: 7
+  deprecate_after_failures: 30
+
 ci:
   fail_on_warning: false
-  post_pr_comment: true
+  post_pr_comment: false  # reserved for future GitHub integration
   output_format: markdown
 ```
 
@@ -61,18 +66,23 @@ Path to `skill-catalog.yaml`. Default: `./skill-catalog.yaml`
 ### `secure.*`
 - `block_on` (list[str]) severities that cause failure (critical/high/medium/low)
 - `allow_external_urls_in_scripts` (bool)
-- `use_snyk_scan` (bool, Phase 3+)
+- `use_snyk_scan` (bool, reserved for future integration)
 - `allow_list` (list) suppress specific findings
 
 ### `conflict.*`
-- `method` (tfidf|embeddings|llm)
+- `method` (tfidf|embeddings|llm, but only `tfidf` is currently supported)
 - `high_overlap_threshold` (float)
 - `medium_overlap_threshold` (float)
 - `block_on_high_overlap` (bool)
 
+### `monitor.*`
+- `stale_threshold_days` (int)
+- `degrade_after_failures` (int; `degrade_after_days` still loads as a deprecated alias)
+- `deprecate_after_failures` (int; `deprecate_after_days` still loads as a deprecated alias)
+
 ### `ci.*`
 - `fail_on_warning` (bool)
-- `post_pr_comment` (bool)
+- `post_pr_comment` (bool, reserved for future integration)
 - `output_format` (text|json|markdown)
 
 ## Environment Variables

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -112,7 +112,7 @@ echo "Restarted $CONTAINER with $(basename "$SKILL_PATH")"
 
 ## Health check after hook
 
-After the pre-test hook runs, skill-guard polls `GET {endpoint}/health` until it returns 200 or `reload_timeout_seconds` is exceeded. Your agent should expose a `/health` endpoint that returns `{"status": "ok"}` when ready.
+After the pre-test hook runs, skill-guard can optionally execute `test.reload_command`, wait `reload_wait_seconds`, then poll `GET {endpoint}{reload_health_check_path}` until it returns 200 or `reload_timeout_seconds` is exceeded. The default health path is `/health`.
 
 ```python
 # FastAPI example

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -48,7 +48,7 @@ test:
 
 monitor:
   stale_threshold_days: 180
-  degrade_after_days: 7
+  degrade_after_failures: 7
   notify:
     slack_webhook: ${SLACK_WEBHOOK_URL}   # optional
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skill-guard"
-version = "0.4.4"
+version = "0.4.5"
 description = "The quality gate for Agent Skills — validate, secure, conflict-detect, and test skills across their full lifecycle"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/skill_guard/commands/check.py
+++ b/skill_guard/commands/check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +14,7 @@ from skill_guard.engine.agent_runner import run_agent_tests
 from skill_guard.engine.quality import run_validation
 from skill_guard.engine.security import run_security_scan
 from skill_guard.engine.similarity import compute_similarity
-from skill_guard.models import SkillParseError
+from skill_guard.models import HealthCheckTimeoutError, HookError, SkillParseError
 from skill_guard.output.json_out import format_as_json
 from skill_guard.parser import parse_skill
 
@@ -21,7 +22,7 @@ SKILL_PATH_ARG = typer.Argument(..., help="Path to skill directory")
 AGAINST_OPT = typer.Option(..., "--against", help="Skills dir or catalog YAML")
 ENDPOINT_OPT = typer.Option(None, "--endpoint", help="Agent endpoint URL")
 CONFIG_OPT = typer.Option(None, "--config", help="Path to skill-guard.yaml")
-FORMAT_OPT = typer.Option("text", "--format", help="Output format: text|json|md")
+FORMAT_OPT = typer.Option(None, "--format", help="Output format: text|json|md")
 
 
 def _emit(payload: dict[str, Any], output_format: str) -> None:
@@ -53,7 +54,7 @@ def check_cmd(
     against: Path = AGAINST_OPT,
     endpoint: str | None = ENDPOINT_OPT,
     config_path: Path | None = CONFIG_OPT,
-    output_format: str = FORMAT_OPT,
+    output_format: str | None = FORMAT_OPT,
 ) -> None:
     """Run validate + secure + conflict + test pipeline for a skill."""
     try:
@@ -65,6 +66,13 @@ def check_cmd(
     except SkillParseError as e:
         typer.echo(f"Parse error: {e}")
         raise typer.Exit(code=4) from e
+
+    resolved_output_format = output_format or config.ci.output_format
+    if config.ci.post_pr_comment:
+        warnings.warn(
+            "ci.post_pr_comment is not yet implemented and has no effect.",
+            stacklevel=2,
+        )
 
     validation = run_validation(skill, config.validate)
     if validation.blockers > 0:
@@ -81,7 +89,7 @@ def check_cmd(
                     "validation": validation.model_dump(mode="json"),
                 },
             },
-            output_format,
+            resolved_output_format,
         )
         raise typer.Exit(code=1)
 
@@ -101,11 +109,14 @@ def check_cmd(
                     "security": security.model_dump(mode="json"),
                 },
             },
-            output_format,
+            resolved_output_format,
         )
         raise typer.Exit(code=1)
-
-    conflict = compute_similarity(skill, against, config.conflict)
+    try:
+        conflict = compute_similarity(skill, against, config.conflict)
+    except ConfigError as e:
+        typer.echo(f"Config error: {e}")
+        raise typer.Exit(code=3) from e
     if not conflict.passed:
         _emit(
             {
@@ -122,7 +133,7 @@ def check_cmd(
                     "conflict": conflict.model_dump(mode="json"),
                 },
             },
-            output_format,
+            resolved_output_format,
         )
         raise typer.Exit(code=1)
 
@@ -132,7 +143,14 @@ def check_cmd(
     test_result = None
     if resolved_endpoint:
         config.test.endpoint = resolved_endpoint
-        test_result = asyncio.run(run_agent_tests(skill, config.test))
+        try:
+            test_result = asyncio.run(run_agent_tests(skill, config.test))
+        except HealthCheckTimeoutError as e:
+            typer.echo(f"Test setup error: {e}")
+            raise typer.Exit(code=6) from e
+        except HookError as e:
+            typer.echo(f"Test setup error: {e}")
+            raise typer.Exit(code=5) from e
         if test_result.passed:
             test_status = "passed"
         elif test_result.failed_tests > 0:
@@ -152,14 +170,15 @@ def check_cmd(
                         "test": test_result.model_dump(mode="json"),
                     },
                 },
-                output_format,
+                resolved_output_format,
             )
             raise typer.Exit(code=1)
         else:
             test_status = "warning"
 
     has_warning = validation_status == "warning" or test_status == "warning"
-    final_status = "warning" if has_warning else "passed"
+    fail_on_warning = config.ci.fail_on_warning and has_warning
+    final_status = "failed" if fail_on_warning else ("warning" if has_warning else "passed")
     _emit(
         {
             "skill_name": skill.metadata.name,
@@ -171,7 +190,11 @@ def check_cmd(
             "summary": (
                 "All blocking checks passed."
                 if not has_warning
-                else "Blocking checks passed with warnings."
+                else (
+                    "Warnings are configured to fail this CI check."
+                    if fail_on_warning
+                    else "Blocking checks passed with warnings."
+                )
             ),
             "result": {
                 "validation": validation.model_dump(mode="json"),
@@ -182,8 +205,10 @@ def check_cmd(
                 ),
             },
         },
-        output_format,
+        resolved_output_format,
     )
 
+    if fail_on_warning:
+        raise typer.Exit(code=1)
     if has_warning:
         raise typer.Exit(code=2)

--- a/skill_guard/commands/conflict.py
+++ b/skill_guard/commands/conflict.py
@@ -43,10 +43,6 @@ def conflict_cmd(
     except SkillParseError as e:
         typer.echo(f"Parse error: {e}")
         raise typer.Exit(code=4) from e
-    except NotImplementedError as e:
-        typer.echo(str(e))
-        raise typer.Exit(code=1) from e
-
     if format == "json":
         typer.echo(format_as_json(result, command="conflict"))
     elif format in ("md", "markdown"):

--- a/skill_guard/commands/monitor.py
+++ b/skill_guard/commands/monitor.py
@@ -108,6 +108,7 @@ def monitor_cmd(
                     }
                 )
                 test_result = asyncio.run(run_agent_tests(skill, test_cfg))
+                manager.increment_eval_count(updated_entry)
                 if not test_result.passed:
                     healthy_checks = False
                     findings.append(

--- a/skill_guard/commands/test.py
+++ b/skill_guard/commands/test.py
@@ -10,7 +10,7 @@ import typer
 
 from skill_guard.config import ConfigError, TestConfig, load_config
 from skill_guard.engine.agent_runner import run_agent_tests
-from skill_guard.models import HookError, SkillParseError
+from skill_guard.models import HealthCheckTimeoutError, HookError, SkillParseError
 from skill_guard.output.json_out import format_as_json
 from skill_guard.parser import parse_skill
 
@@ -88,6 +88,9 @@ def test_cmd(
 
     try:
         result = asyncio.run(run_agent_tests(skill, merged_test_config))
+    except HealthCheckTimeoutError as e:
+        typer.echo(f"Test setup error: {e}")
+        raise typer.Exit(code=6) from e
     except HookError as e:
         typer.echo(f"Test setup error: {e}")
         raise typer.Exit(code=5) from e

--- a/skill_guard/config.py
+++ b/skill_guard/config.py
@@ -11,7 +11,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 from ruamel.yaml import YAML
 
 from skill_guard.models import ConfigError
@@ -74,12 +74,14 @@ class ValidateConfig(BaseModel):
 class SecureConfig(BaseModel):
     block_on: list[str] = Field(default_factory=lambda: ["critical", "high"])
     allow_external_urls_in_scripts: bool = False
+    # Reserved for future integration with the snyk CLI.
     use_snyk_scan: bool = False
     allow_list: list[AllowListEntry] = Field(default_factory=list)
 
 
 class ConflictConfig(BaseModel):
     similarity_threshold: float = 0.70
+    # Future note: tfidf is the only supported conflict detection method today.
     method: Literal["tfidf", "embeddings", "llm"] = "tfidf"
     block_on_high_overlap: bool = True
     high_overlap_threshold: float = 0.75
@@ -114,17 +116,35 @@ class NotifyConfig(BaseModel):
 
 class MonitorConfig(BaseModel):
     stale_threshold_days: int = 180
-    degrade_after_days: int = 7
-    deprecate_after_days: int = 30
+    degrade_after_failures: int = Field(
+        7,
+        validation_alias=AliasChoices("degrade_after_failures", "degrade_after_days"),
+        description="Move a production skill to degraded after this many consecutive eval failures.",
+    )
+    deprecate_after_failures: int = Field(
+        30,
+        validation_alias=AliasChoices("deprecate_after_failures", "deprecate_after_days"),
+        description="Move a degraded skill to deprecated after this many consecutive eval failures.",
+    )
     check_ownership: bool = True
     ownership_files: list[str] = Field(default_factory=lambda: ["CODEOWNERS", "MAINTAINERS"])
     ownership_fallback: Literal["warn", "skip"] = "warn"
     notify: NotifyConfig = Field(default_factory=NotifyConfig)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_on_deprecated_day_keys(cls, value: Any) -> Any:
+        if isinstance(value, dict) and (
+            "degrade_after_days" in value or "deprecate_after_days" in value
+        ):
+            value = dict(value)
+        return value
+
 
 class CIConfig(BaseModel):
     fail_on_warning: bool = False
-    post_pr_comment: bool = True
+    # Reserved for future GitHub API integration.
+    post_pr_comment: bool = False
     output_format: Literal["text", "json", "markdown"] = "markdown"
 
 
@@ -269,7 +289,7 @@ validate:
 secure:
   block_on: [critical, high]       # Severities that cause a blocking failure
   allow_external_urls_in_scripts: false
-  use_snyk_scan: false             # Requires snyk CLI (future feature)
+  use_snyk_scan: false             # Reserved for future snyk CLI integration
   # allow_list:                    # Suppress specific findings
   #   - id: EXEC-001
   #     reason: "Standard install pattern"
@@ -279,7 +299,7 @@ secure:
 # Conflict detection (skill-guard conflict)
 # ─────────────────────────────────────────────
 conflict:
-  method: tfidf                    # tfidf | embeddings | llm
+  method: tfidf                    # Only supported today; embeddings/llm are future modes
   high_overlap_threshold: 0.75    # >= this = HIGH conflict
   medium_overlap_threshold: 0.55  # >= this = MEDIUM conflict
   block_on_high_overlap: true
@@ -304,8 +324,8 @@ conflict:
 # ─────────────────────────────────────────────
 # monitor:
 #   stale_threshold_days: 180
-#   degrade_after_days: 7
-#   deprecate_after_days: 30
+#   degrade_after_failures: 7
+#   deprecate_after_failures: 30
 #   notify:
 #     slack_webhook: ${SLACK_WEBHOOK_URL}
 
@@ -314,6 +334,6 @@ conflict:
 # ─────────────────────────────────────────────
 ci:
   fail_on_warning: false
-  post_pr_comment: true
+  post_pr_comment: false           # Reserved for future GitHub PR comment support
   output_format: markdown
 """

--- a/skill_guard/engine/agent_runner.py
+++ b/skill_guard/engine/agent_runner.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
 import httpx
 
@@ -15,6 +16,7 @@ from skill_guard.models import (
     AgentTestResult,
     EvalExpectation,
     EvalTestResult,
+    HealthCheckTimeoutError,
     HookError,
     ParsedSkill,
 )
@@ -35,9 +37,14 @@ def run_hook(hook_script: Path, skill_path: Path, endpoint: str) -> None:
         raise HookError(f"Hook failed ({hook_script}) with exit code {proc.returncode}: {details}")
 
 
-async def wait_for_agent_ready(endpoint: str, api_key: str | None, timeout_seconds: int) -> None:
+async def wait_for_agent_ready(
+    endpoint: str,
+    api_key: str | None,
+    timeout_seconds: int,
+    health_check_path: str = "/health",
+) -> None:
     """Poll endpoint health until ready or timeout."""
-    health_url = f"{endpoint.rstrip('/')}/health"
+    health_url = urljoin(f"{endpoint.rstrip('/')}/", health_check_path.lstrip("/"))
     headers = _build_headers(api_key)
     deadline = time.monotonic() + timeout_seconds
 
@@ -51,7 +58,7 @@ async def wait_for_agent_ready(endpoint: str, api_key: str | None, timeout_secon
                 pass
             await asyncio.sleep(1)
 
-    raise HookError(
+    raise HealthCheckTimeoutError(
         f"Timed out waiting for agent health at '{health_url}' after {timeout_seconds}s"
     )
 
@@ -69,16 +76,26 @@ async def run_agent_tests(skill: ParsedSkill, config: TestConfig) -> AgentTestRe
     pre_hook = config.injection.pre_test_hook
     post_hook = config.injection.post_test_hook
 
-    if pre_hook:
-        run_hook(Path(pre_hook), skill.path, endpoint)
-        await wait_for_agent_ready(endpoint, config.api_key, config.reload_timeout_seconds)
-
     started = time.perf_counter()
     results: list[EvalTestResult] = []
 
     headers = _build_headers(config.api_key)
 
     try:
+        if pre_hook:
+            run_hook(Path(pre_hook), skill.path, endpoint)
+        if config.reload_command:
+            _run_reload_command(config.reload_command)
+            if config.reload_wait_seconds > 0:
+                await asyncio.sleep(config.reload_wait_seconds)
+        if pre_hook or config.reload_command:
+            await wait_for_agent_ready(
+                endpoint,
+                config.api_key,
+                config.reload_timeout_seconds,
+                config.reload_health_check_path,
+            )
+
         async with httpx.AsyncClient(timeout=config.timeout_seconds) as client:
             for test in skill.evals_config.tests:
                 prompt_path = skill.path / "evals" / test.prompt_file
@@ -139,6 +156,17 @@ async def run_agent_tests(skill: ParsedSkill, config: TestConfig) -> AgentTestRe
         avg_latency_ms=avg_latency_ms,
         passed=failed_tests == 0,
     )
+
+
+def _run_reload_command(command: str) -> None:
+    proc = subprocess.run(command, shell=True, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        stdout = proc.stdout.strip()
+        details = stderr or stdout or "No output."
+        raise HookError(
+            f"Reload command failed with exit code {proc.returncode}: {details}"
+        )
 
 
 def _extract_response_data(response_body: dict[str, Any]) -> tuple[str, list[str]]:

--- a/skill_guard/engine/catalog_manager.py
+++ b/skill_guard/engine/catalog_manager.py
@@ -124,3 +124,8 @@ class CatalogManager:
         for entry in catalog.skills:
             stats[entry.stage] = stats.get(entry.stage, 0) + 1
         return stats
+
+    def increment_eval_count(self, entry: CatalogEntry) -> CatalogEntry:
+        """Track a completed eval run for a catalog entry."""
+        entry.eval_count += 1
+        return entry

--- a/skill_guard/engine/lifecycle.py
+++ b/skill_guard/engine/lifecycle.py
@@ -19,18 +19,20 @@ def apply_stage_transitions(
     original_stage = updated.stage
     failures = updated.consecutive_eval_failures
 
-    if original_stage == "production" and failures >= config.degrade_after_days:
+    if original_stage == "production" and failures >= config.degrade_after_failures:
         updated.stage = "degraded"
         messages.append(
             f"{updated.name}: stage transitioned production -> degraded "
-            f"(consecutive_eval_failures={failures})"
+            f"(consecutive_eval_failures={failures}, "
+            f"degrade_after_failures={config.degrade_after_failures})"
         )
 
-    if updated.stage == "degraded" and failures >= config.deprecate_after_days:
+    if updated.stage == "degraded" and failures >= config.deprecate_after_failures:
         updated.stage = "deprecated"
         messages.append(
             f"{updated.name}: stage transitioned degraded -> deprecated "
-            f"(consecutive_eval_failures={failures})"
+            f"(consecutive_eval_failures={failures}, "
+            f"deprecate_after_failures={config.deprecate_after_failures})"
         )
 
     return updated, messages

--- a/skill_guard/engine/security.py
+++ b/skill_guard/engine/security.py
@@ -5,8 +5,10 @@ Security scanner — regex-based pattern matching with suppression support.
 from __future__ import annotations
 
 import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 from skill_guard.config import SecureConfig
 from skill_guard.models import ParsedSkill, SecurityFinding, SecurityResult
@@ -132,6 +134,9 @@ _SUPPRESSION_RE = re.compile(r"skill-guard:\s*ignore\s+([A-Z]+-\d+)")
 
 def run_security_scan(skill: ParsedSkill, config: SecureConfig) -> SecurityResult:
     """Scan skill files for dangerous patterns and return SecurityResult."""
+    if config.use_snyk_scan:
+        warnings.warn("use_snyk_scan is not yet implemented.", stacklevel=2)
+
     findings: list[SecurityFinding] = []
 
     files_to_scan = _gather_files(skill)
@@ -185,6 +190,9 @@ def run_security_scan(skill: ParsedSkill, config: SecureConfig) -> SecurityResul
                         suppressed=suppressed,
                     )
                 )
+
+        if not config.allow_external_urls_in_scripts and file_path in skill.scripts:
+            findings.extend(_scan_external_urls(file_path, text))
 
     # Counts (excluding suppressed for pass/fail logic)
     crit = sum(1 for f in findings if f.severity == "critical" and not f.suppressed)
@@ -250,3 +258,35 @@ def _redact_if_credential(pattern_id: str, matched_text: str) -> str:
             return "****"
         return matched_text[:4] + "****"
     return matched_text
+
+
+def _scan_external_urls(file_path: Path, text: str) -> list[SecurityFinding]:
+    findings: list[SecurityFinding] = []
+
+    for match in re.finditer(r"https?://[^\s\"')>]+", text):
+        url = match.group(0)
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").lower()
+        if hostname in {"localhost", "127.0.0.1", "::1"}:
+            continue
+
+        line_no = text[: match.start()].count("\n") + 1
+        findings.append(
+            SecurityFinding(
+                id="URL-001",
+                severity="medium",
+                category="DATA_EXFILTRATION",
+                file=str(file_path),
+                line=line_no,
+                pattern=r"https?://[^\s\"')>]+",
+                matched_text=url,
+                description="External URL found in script file",
+                suggestion=(
+                    "Avoid external URLs in scripts, or set "
+                    "secure.allow_external_urls_in_scripts: true when intentional."
+                ),
+                suppressed=False,
+            )
+        )
+
+    return findings

--- a/skill_guard/engine/similarity.py
+++ b/skill_guard/engine/similarity.py
@@ -14,7 +14,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
 from skill_guard.config import ConflictConfig
-from skill_guard.models import ConflictMatch, ConflictResult, ParsedSkill, SkillParseError
+from skill_guard.models import ConfigError, ConflictMatch, ConflictResult, ParsedSkill, SkillParseError
 from skill_guard.parser import parse_skill
 
 _TRIGGER_RE = re.compile(r"use when[^.]+\.?", re.IGNORECASE)
@@ -32,13 +32,13 @@ def compute_similarity(
     threshold = threshold or config.similarity_threshold
 
     if method == "embeddings":
-        raise NotImplementedError(
-            "Embeddings method is not available in Phase 1. "
-            "Install skill-guard[embeddings] and use Phase 3."
+        raise ConfigError(
+            "Embeddings conflict detection is not yet implemented. "
+            "Use method: tfidf (default)."
         )
     if method == "llm":
-        raise NotImplementedError(
-            "LLM-based conflict detection is planned for Phase 3. Use method=tfidf in Phase 1."
+        raise ConfigError(
+            "LLM conflict detection is not yet implemented. Use method: tfidf (default)."
         )
 
     # Apply threshold override (treat as medium threshold)

--- a/skill_guard/main.py
+++ b/skill_guard/main.py
@@ -3,6 +3,13 @@
 from __future__ import annotations
 
 import importlib.metadata
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from urllib.request import urlopen
 
 import typer
 
@@ -12,6 +19,8 @@ from skill_guard.commands.check import check_cmd
 from skill_guard.commands.monitor import monitor_cmd
 
 app = typer.Typer(name="skill-guard", help="The quality gate for Agent Skills.")
+_VERSION_CHECK_CACHE_PATH = Path.home() / ".cache" / "skill-guard" / "version-check"
+_VERSION_CHECK_TTL_SECONDS = 24 * 60 * 60
 
 
 def _version_callback(value: bool) -> None:
@@ -32,6 +41,75 @@ def main(
     ),
 ) -> None:
     """The quality gate for Agent Skills."""
+    _start_version_check()
+
+
+def _start_version_check() -> None:
+    if os.environ.get("SKILL_GUARD_NO_UPDATE_CHECK") == "1":
+        return
+
+    cached_latest = _read_cached_latest_version()
+    if cached_latest is not None:
+        _print_update_notice_if_needed(cached_latest)
+        return
+
+    thread = threading.Thread(target=_refresh_version_cache, daemon=True)
+    thread.start()
+
+
+def _read_cached_latest_version() -> str | None:
+    if not _VERSION_CHECK_CACHE_PATH.exists():
+        return None
+
+    try:
+        if time.time() - _VERSION_CHECK_CACHE_PATH.stat().st_mtime >= _VERSION_CHECK_TTL_SECONDS:
+            return None
+        payload = json.loads(_VERSION_CHECK_CACHE_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    latest = payload.get("latest")
+    return latest if isinstance(latest, str) and latest else None
+
+
+def _refresh_version_cache() -> None:
+    try:
+        with urlopen("https://pypi.org/pypi/skill-guard/json", timeout=3) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        latest = payload.get("info", {}).get("version")
+        if not isinstance(latest, str) or not latest:
+            return
+
+        _VERSION_CHECK_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _VERSION_CHECK_CACHE_PATH.write_text(
+            json.dumps({"latest": latest, "checked_at": int(time.time())}),
+            encoding="utf-8",
+        )
+        _print_update_notice_if_needed(latest)
+    except Exception:
+        return
+
+
+def _print_update_notice_if_needed(latest: str) -> None:
+    try:
+        current = importlib.metadata.version("skill-guard")
+    except importlib.metadata.PackageNotFoundError:
+        return
+
+    if _version_tuple(latest) > _version_tuple(current):
+        print(
+            f"ℹ️  skill-guard {latest} available — upgrade: pip install --upgrade skill-guard",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for part in version.split("."):
+        digits = "".join(ch for ch in part if ch.isdigit())
+        parts.append(int(digits or 0))
+    return tuple(parts)
 
 
 # Register subcommands

--- a/skill_guard/models.py
+++ b/skill_guard/models.py
@@ -324,3 +324,7 @@ class ConfigError(SkillGateError):
 
 class HookError(SkillGateError):
     """Raised when a pre/post test hook fails."""
+
+
+class HealthCheckTimeoutError(HookError):
+    """Raised when the agent health check does not become ready in time."""

--- a/tests/unit/test_agent_runner.py
+++ b/tests/unit/test_agent_runner.py
@@ -8,7 +8,7 @@ import pytest
 from skill_guard.config import TestConfig as RunnerConfig
 from skill_guard.engine import agent_runner
 from skill_guard.engine.agent_runner import run_agent_tests, run_hook, wait_for_agent_ready
-from skill_guard.models import HookError
+from skill_guard.models import HealthCheckTimeoutError, HookError
 from skill_guard.parser import parse_skill
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "skills"
@@ -202,5 +202,106 @@ async def test_wait_for_agent_ready_timeout(monkeypatch: pytest.MonkeyPatch) -> 
         return httpx.Response(503)
 
     _patch_async_client(monkeypatch, handler)
-    with pytest.raises(HookError):
+    with pytest.raises(HealthCheckTimeoutError):
         await wait_for_agent_ready("https://mock-agent.test", None, timeout_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_agent_ready_uses_custom_health_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = {"path": ""}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        return httpx.Response(200)
+
+    _patch_async_client(monkeypatch, handler)
+    await wait_for_agent_ready(
+        "https://mock-agent.test",
+        None,
+        timeout_seconds=1,
+        health_check_path="/readyz",
+    )
+
+    assert seen["path"] == "/readyz"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_tests_runs_post_hook_after_pre_hook_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = parse_skill(FIXTURES / "valid-skill")
+    calls: list[tuple[str, str]] = []
+
+    def fake_run_hook(hook_script: Path, skill_path: Path, endpoint: str) -> None:
+        calls.append((hook_script.name, endpoint))
+        if hook_script.name == "pre.sh":
+            raise HookError("pre hook failed")
+
+    monkeypatch.setattr(agent_runner, "run_hook", fake_run_hook)
+
+    config = RunnerConfig(
+        endpoint="https://mock-agent.test",
+        model="gpt-4.1",
+        injection={
+            "pre_test_hook": str(skill.path / "pre.sh"),
+            "post_test_hook": str(skill.path / "post.sh"),
+        },
+    )
+
+    with pytest.raises(HookError, match="pre hook failed"):
+        await run_agent_tests(skill, config)
+
+    assert calls == [("pre.sh", "https://mock-agent.test"), ("post.sh", "https://mock-agent.test")]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_tests_runs_reload_command_and_waits_for_custom_health_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = parse_skill(FIXTURES / "valid-skill")
+    calls: list[str] = []
+
+    def fake_reload_command(command: str) -> None:
+        calls.append(f"reload:{command}")
+
+    async def fake_wait_for_agent_ready(endpoint: str, api_key, timeout_seconds: int, health_check_path: str = "/health") -> None:  # noqa: ANN001
+        calls.append(f"health:{endpoint}:{timeout_seconds}:{health_check_path}")
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "diagnostic latency"}],
+                    }
+                ]
+            },
+        )
+
+    _patch_async_client(monkeypatch, handler)
+    monkeypatch.setattr(agent_runner, "_run_reload_command", fake_reload_command)
+    monkeypatch.setattr(agent_runner, "wait_for_agent_ready", fake_wait_for_agent_ready)
+
+    sleep_calls: list[int] = []
+
+    async def fake_sleep(seconds: int) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(agent_runner.asyncio, "sleep", fake_sleep)
+
+    config = RunnerConfig(
+        endpoint="https://mock-agent.test",
+        model="gpt-4.1",
+        reload_command="echo reload",
+        reload_wait_seconds=2,
+        reload_health_check_path="/readyz",
+    )
+    await run_agent_tests(skill, config)
+
+    assert calls[0] == "reload:echo reload"
+    assert calls[1] == "health:https://mock-agent.test:60:/readyz"
+    assert sleep_calls == [2]

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -130,3 +130,12 @@ def test_atomic_save_file_exists_after_save(tmp_path: Path) -> None:
     manager.save_catalog(catalog, catalog_path)
 
     assert catalog_path.exists()
+
+
+def test_increment_eval_count_updates_entry() -> None:
+    manager = CatalogManager()
+    entry = _entry("alpha", "production")
+
+    manager.increment_eval_count(entry)
+
+    assert entry.eval_count == 1

--- a/tests/unit/test_check_cmd.py
+++ b/tests/unit/test_check_cmd.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 
 import skill_guard.commands.check as check_cmd_module
 from skill_guard.main import app
-from skill_guard.models import AgentTestResult
+from skill_guard.models import AgentTestResult, CheckResult, ValidationResult
 
 runner = CliRunner()
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "skills"
@@ -23,7 +23,7 @@ def test_check_valid_skill(tmp_path: Path) -> None:
         ["check", str(FIXTURES / "valid-skill"), "--against", str(against_dir)],
     )
     assert result.exit_code == 0
-    assert "status=passed" in result.stdout
+    assert "- status: passed" in result.stdout
 
 
 def test_check_malicious_skill(tmp_path: Path) -> None:
@@ -35,7 +35,7 @@ def test_check_malicious_skill(tmp_path: Path) -> None:
         ["check", str(FIXTURES / "malicious-skill"), "--against", str(against_dir)],
     )
     assert result.exit_code == 1
-    assert "security=failed" in result.stdout
+    assert "- security: failed" in result.stdout
 
 
 def test_check_with_format_json(tmp_path: Path) -> None:
@@ -102,3 +102,85 @@ def test_check_runs_agent_evals_when_endpoint_provided(tmp_path: Path, monkeypat
     payload = json.loads(result.stdout)
     assert payload["result"]["test"] == "passed"
     assert payload["result"]["result"]["test"]["passed"] is True
+
+
+def test_check_uses_ci_output_format_from_config_when_flag_omitted(tmp_path: Path) -> None:
+    against_dir = tmp_path / "against"
+    config_path = tmp_path / "skill-guard.yaml"
+    shutil.copytree(FIXTURES / "valid-skill", against_dir / "valid-skill")
+    config_path.write_text(
+        (
+            "ci:\n"
+            "  output_format: json\n"
+            "  post_pr_comment: false\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(FIXTURES / "valid-skill"),
+            "--against",
+            str(against_dir),
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "check"
+
+
+def test_check_fail_on_warning_exits_one(tmp_path: Path, monkeypatch) -> None:
+    against_dir = tmp_path / "against"
+    config_path = tmp_path / "skill-guard.yaml"
+    shutil.copytree(FIXTURES / "valid-skill", against_dir / "valid-skill")
+    config_path.write_text(
+        (
+            "ci:\n"
+            "  fail_on_warning: true\n"
+            "  post_pr_comment: false\n"
+            "  output_format: json\n"
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run_validation(skill, config):  # noqa: ARG001
+        return ValidationResult(
+            skill_name=skill.metadata.name,
+            skill_path=skill.path,
+            checks=[
+                CheckResult(
+                    check_name="warning-check",
+                    passed=True,
+                    severity="warning",
+                    message="warning",
+                )
+            ],
+            score=90,
+            grade="A",
+            passed=True,
+            warnings=1,
+            blockers=0,
+        )
+
+    monkeypatch.setattr(check_cmd_module, "run_validation", fake_run_validation)
+
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(FIXTURES / "valid-skill"),
+            "--against",
+            str(against_dir),
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["result"]["status"] == "failed"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -38,3 +38,20 @@ def test_missing_env_var(tmp_path: Path):
     config_file.write_text("""\nskills_dir: ${NOT_SET}\n""", encoding="utf-8")
     with pytest.raises(ConfigError):
         load_config(config_file)
+
+
+def test_monitor_failure_aliases_load_from_legacy_keys(tmp_path: Path) -> None:
+    config_file = tmp_path / "skill-guard.yaml"
+    config_file.write_text(
+        (
+            "monitor:\n"
+            "  degrade_after_days: 3\n"
+            "  deprecate_after_days: 9\n"
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(config_file)
+
+    assert cfg.monitor.degrade_after_failures == 3
+    assert cfg.monitor.deprecate_after_failures == 9

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -25,17 +25,19 @@ def _entry(stage: str = "production", failures: int = 0) -> CatalogEntry:
 
 
 def test_apply_stage_transitions_production_to_degraded() -> None:
-    cfg = MonitorConfig(degrade_after_days=7, deprecate_after_days=30)
+    cfg = MonitorConfig(degrade_after_failures=7, deprecate_after_failures=30)
     updated, msgs = apply_stage_transitions(_entry(stage="production", failures=7), cfg, Path("."))
     assert updated.stage == "degraded"
     assert any("production -> degraded" in msg for msg in msgs)
+    assert any("degrade_after_failures=7" in msg for msg in msgs)
 
 
 def test_apply_stage_transitions_degraded_to_deprecated() -> None:
-    cfg = MonitorConfig(degrade_after_days=7, deprecate_after_days=30)
+    cfg = MonitorConfig(degrade_after_failures=7, deprecate_after_failures=30)
     updated, msgs = apply_stage_transitions(_entry(stage="degraded", failures=30), cfg, Path("."))
     assert updated.stage == "deprecated"
     assert any("degraded -> deprecated" in msg for msg in msgs)
+    assert any("deprecate_after_failures=30" in msg for msg in msgs)
 
 
 def test_check_staleness_warns_when_old() -> None:

--- a/tests/unit/test_monitor_cmd.py
+++ b/tests/unit/test_monitor_cmd.py
@@ -35,8 +35,8 @@ def _write_config(path: Path, degrade_after: int = 7) -> None:
         (
             "monitor:\n"
             "  stale_threshold_days: 99999\n"
-            f"  degrade_after_days: {degrade_after}\n"
-            "  deprecate_after_days: 30\n"
+            f"  degrade_after_failures: {degrade_after}\n"
+            "  deprecate_after_failures: 30\n"
             "  check_ownership: false\n"
         ),
         encoding="utf-8",
@@ -104,6 +104,56 @@ def test_monitor_cmd_transitions_to_degraded_and_fails(tmp_path: Path) -> None:
     assert result.exit_code == 1
     updated_catalog = manager.load_catalog(catalog_path)
     assert updated_catalog.skills[0].stage == "degraded"
+
+
+def test_monitor_cmd_increments_eval_count_after_completed_eval(tmp_path: Path, monkeypatch) -> None:
+    catalog_path = tmp_path / "catalog.yaml"
+    config_path = tmp_path / "skill-guard.yaml"
+    manager = CatalogManager()
+    skill_path = str((FIXTURES / "valid-skill").resolve())
+    catalog = Catalog(
+        updated=datetime.now(UTC),
+        skills=[_entry("valid-skill", "production", skill_path)],
+    )
+    manager.save_catalog(catalog, catalog_path)
+    _write_config(config_path)
+
+    async def fake_run_agent_tests(skill, test_config):  # noqa: ARG001
+        from skill_guard.models import AgentTestResult
+
+        return AgentTestResult(
+            skill_name=skill.metadata.name,
+            endpoint=test_config.endpoint or "",
+            total_tests=1,
+            passed_tests=1,
+            failed_tests=0,
+            pass_rate=1.0,
+            results=[],
+            total_time_seconds=0.0,
+            avg_latency_ms=1.0,
+            passed=True,
+        )
+
+    monkeypatch.setattr("skill_guard.commands.monitor.run_agent_tests", fake_run_agent_tests)
+
+    result = runner.invoke(
+        app,
+        [
+            "monitor",
+            "--catalog",
+            str(catalog_path),
+            "--config",
+            str(config_path),
+            "--endpoint",
+            "https://agent.test",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    updated_catalog = manager.load_catalog(catalog_path)
+    assert updated_catalog.skills[0].eval_count == 1
 
 
 def test_monitor_cmd_html_output(tmp_path: Path) -> None:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -13,3 +13,19 @@ def test_security_malicious_skill():
     assert result.passed is False
     assert result.critical_count >= 1
     assert result.high_count >= 1
+
+
+def test_security_flags_external_urls_in_scripts_by_default() -> None:
+    skill = parse_skill(FIXTURES / "malicious-skill")
+
+    result = run_security_scan(skill, SecureConfig())
+
+    assert any(f.id == "URL-001" for f in result.findings)
+
+
+def test_security_allows_external_urls_when_enabled() -> None:
+    skill = parse_skill(FIXTURES / "malicious-skill")
+
+    result = run_security_scan(skill, SecureConfig(allow_external_urls_in_scripts=True))
+
+    assert all(f.id != "URL-001" for f in result.findings)

--- a/tests/unit/test_similarity.py
+++ b/tests/unit/test_similarity.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
+import re
+import pytest
+
 from skill_guard.config import ConflictConfig
 from skill_guard.engine.similarity import compute_similarity
+from skill_guard.models import ConfigError
 from skill_guard.parser import parse_skill
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "skills"
@@ -18,3 +22,23 @@ def test_conflict_self_excluded():
     result = compute_similarity(new_skill, FIXTURES, ConflictConfig())
     # Should not conflict with itself
     assert all(m.existing_skill_name != "valid-skill" for m in result.matches)
+
+
+@pytest.mark.parametrize(
+    ("method", "message"),
+    [
+        (
+            "embeddings",
+            "Embeddings conflict detection is not yet implemented. Use method: tfidf (default).",
+        ),
+        (
+            "llm",
+            "LLM conflict detection is not yet implemented. Use method: tfidf (default).",
+        ),
+    ],
+)
+def test_conflict_unsupported_method_raises_config_error(method: str, message: str) -> None:
+    new_skill = parse_skill(FIXTURES / "valid-skill")
+
+    with pytest.raises(ConfigError, match=re.escape(message)):
+        compute_similarity(new_skill, FIXTURES, ConflictConfig(method=method))

--- a/tests/unit/test_test_cmd.py
+++ b/tests/unit/test_test_cmd.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from skill_guard.main import app
-from skill_guard.models import AgentTestResult, EvalTestResult, HookError
+from skill_guard.models import AgentTestResult, EvalTestResult, HealthCheckTimeoutError, HookError
 
 runner = CliRunner()
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "skills"
@@ -180,4 +180,24 @@ def test_test_cmd_exits_five_on_hook_error(monkeypatch) -> None:
         ],
     )
     assert result.exit_code == 5
+    assert "Test setup error" in result.stdout
+
+
+def test_test_cmd_exits_six_on_health_check_timeout(monkeypatch) -> None:
+    async def fake_run_agent_tests(skill, config):  # noqa: ARG001
+        raise HealthCheckTimeoutError("agent never became ready")
+
+    monkeypatch.setattr("skill_guard.commands.test.run_agent_tests", fake_run_agent_tests)
+    result = runner.invoke(
+        app,
+        [
+            "test",
+            str(FIXTURES / "valid-skill"),
+            "--endpoint",
+            "https://mock-agent.test",
+            "--model",
+            "gpt-4.1",
+        ],
+    )
+    assert result.exit_code == 6
     assert "Test setup error" in result.stdout


### PR DESCRIPTION
## Summary

Closes #50 #52 #53 #54 #55 #56 #57 #58 #59 #60

All 10 open issues fixed in a single well-tested commit. 78 tests passing, 81.37% coverage.

---

### Changes

| Issue | Fix |
|---|---|
| #52 | `NotImplementedError` → `ConfigError` for embeddings conflict mode |
| #53 | `NotImplementedError` → `ConfigError` for LLM conflict mode |
| #54 | Added `HealthCheckTimeoutError` — exit code 6 (timeout) vs 5 (hook failure) |
| #55 | Moved pre-hook inside `try` block so post-hook always runs on failure |
| #56 | Renamed `degrade_after_days` → `degrade_after_failures` with backward-compat alias |
| #57 | Wired `ci.fail_on_warning` and `ci.output_format` into `check` command |
| #58 | Wired `reload_command`, `allow_external_urls_in_scripts`; marked `use_snyk_scan` future |
| #59 | Increments `CatalogEntry.eval_count` after each successful eval run in monitor |
| #60 | Stage transition messages now reference `degrade_after_failures` config name |
| #50 | Background version check on every run — 24h cache, `SKILL_GUARD_NO_UPDATE_CHECK=1` opt-out |

### Test Results
```
78 passed, 20 warnings in 6.69s
Coverage: 81.37% (threshold: 80%)
```

### Version bump
0.4.4 → 0.4.5