### PR TITLE
feat(v0.6): embeddings + LLM conflict detection, optional extras, caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.6.0 — 2026-03-16
+
+### New Features & Fixes
+
+- **feat:** embeddings-based conflict detection via `sentence-transformers` (`all-MiniLM-L6-v2`) with on-disk caching in `.skill-guard-cache/embeddings/`
+- **feat:** LLM-based conflict detection via OpenAI Chat API (`gpt-4o-mini`) with async fan-out, max concurrency control, and 30-second request timeout
+- **feat:** new conflict config fields: `embeddings_cache_dir`, `llm_model`, and `llm_max_concurrent`
+- **packaging:** optional extras now include `skill-guard[embeddings]` and `skill-guard[llm]`
+- **docs:** README and configuration docs now document live embeddings and LLM conflict modes
+
+---
+
 ## v0.5.0 — 2026-03-16
 
 ### New Features & Fixes

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ skill-guard secure ./skills/my-skill/
 # Check for conflicts with existing skills
 skill-guard conflict ./skills/my-skill/ --against ./skills/
 
-# Note: Currently only tfidf is supported. embeddings and llm are planned for v0.6.
-
 # Run the full gate (validate + secure + conflict; test runs if --endpoint is configured)
 skill-guard check ./skills/my-skill/ --against ./skills/
 ```
@@ -100,9 +98,28 @@ Score: 97/100 | Grade: A | Blockers: 0 | Warnings: 1
 # Core (static analysis — no agent required)
 pip install skill-guard
 
-# Optional future extras for planned embedding-based conflict detection
+# Optional embeddings support
 pip install skill-guard[embeddings]
+
+# Optional LLM-based conflict detection
+pip install skill-guard[llm]
 ```
+
+## Conflict Detection Modes
+
+```bash
+# TF-IDF (default)
+skill-guard conflict ./skills/my-skill/ --against ./skills/ --method tfidf
+
+# Embeddings-based overlap detection
+skill-guard conflict ./skills/my-skill/ --against ./skills/ --method embeddings
+
+# LLM-based overlap detection
+export OPENAI_API_KEY=...
+skill-guard conflict ./skills/my-skill/ --against ./skills/ --method llm
+```
+
+`embeddings` uses the `all-MiniLM-L6-v2` sentence-transformers model and caches vectors under `.skill-guard-cache/embeddings/`. `llm` uses the OpenAI Chat API with `gpt-4o-mini` by default.
 
 ## Documentation
 
@@ -134,7 +151,7 @@ Use `pre-commit` to enforce checks before skill changes land:
 ```yaml
 repos:
   - repo: https://github.com/vaibhavtupe/skill-guard
-    rev: v0.5.0
+    rev: v0.6.0
     hooks:
       - id: skill-guard-validate
       - id: skill-guard-secure

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -29,10 +29,13 @@ secure:
       file: scripts/setup.sh
 
 conflict:
-  method: tfidf  # the only supported method today
+  method: tfidf
   high_overlap_threshold: 0.75
   medium_overlap_threshold: 0.55
   block_on_high_overlap: true
+  embeddings_cache_dir: .skill-guard-cache/embeddings
+  llm_model: gpt-4o-mini
+  llm_max_concurrent: 5
 
 monitor:
   stale_threshold_days: 180
@@ -70,11 +73,13 @@ Path to `skill-catalog.yaml`. Default: `./skill-catalog.yaml`
 - `allow_list` (list) suppress specific findings
 
 ### `conflict.*`
-- `method` (tfidf|embeddings|llm, but only `tfidf` is currently supported)
-- Currently only `tfidf` is supported. `embeddings` and `llm` are planned for v0.6.
+- `method` (`tfidf`|`embeddings`|`llm`)
 - `high_overlap_threshold` (float)
 - `medium_overlap_threshold` (float)
 - `block_on_high_overlap` (bool)
+- `embeddings_cache_dir` (string, default `.skill-guard-cache/embeddings`)
+- `llm_model` (string, default `gpt-4o-mini`)
+- `llm_max_concurrent` (int, default `5`)
 
 ### `monitor.*`
 - `stale_threshold_days` (int)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skill-guard"
-version = "0.5.0"
+version = "0.6.0"
 description = "The quality gate for Agent Skills — validate, secure, conflict-detect, and test skills across their full lifecycle"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -31,7 +31,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-embeddings = ["sentence-transformers>=2.7"]
+embeddings = ["sentence-transformers"]
+llm = ["openai>=1.0"]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/skill_guard/config.py
+++ b/skill_guard/config.py
@@ -82,12 +82,13 @@ class SecureConfig(BaseModel):
 
 class ConflictConfig(BaseModel):
     similarity_threshold: float = 0.70
-    # Future note: tfidf is the only supported conflict detection method today.
     method: Literal["tfidf", "embeddings", "llm"] = "tfidf"
     block_on_high_overlap: bool = True
     high_overlap_threshold: float = 0.75
     medium_overlap_threshold: float = 0.55
-    llm_model: str | None = None
+    embeddings_cache_dir: str = ".skill-guard-cache/embeddings"
+    llm_model: str = "gpt-4o-mini"
+    llm_max_concurrent: int = 5
 
 
 class InjectionConfig(BaseModel):

--- a/skill_guard/engine/similarity.py
+++ b/skill_guard/engine/similarity.py
@@ -1,14 +1,19 @@
 """
-Conflict detection — TF-IDF similarity engine (Phase 1).
+Conflict detection similarity engine.
 """
 
 from __future__ import annotations
 
+import asyncio
 import difflib
+import hashlib
+import json
+import os
 import re
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
+import numpy as np
 from ruamel.yaml import YAML
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
@@ -24,6 +29,8 @@ from skill_guard.models import (
 from skill_guard.parser import parse_skill
 
 _TRIGGER_RE = re.compile(r"use when[^.]+\.?", re.IGNORECASE)
+_EMBEDDINGS_MODEL_NAME = "all-MiniLM-L6-v2"
+_LLM_TIMEOUT_SECONDS = 30
 
 
 def compute_similarity(
@@ -37,45 +44,52 @@ def compute_similarity(
     method = method or config.method
     threshold = threshold or config.similarity_threshold
 
-    if method == "embeddings":
-        raise ConfigError(
-            "Embeddings conflict detection is not yet implemented. Use method: tfidf (default)."
-        )
-    if method == "llm":
-        raise ConfigError(
-            "LLM conflict detection is not yet implemented. Use method: tfidf (default)."
-        )
-
     # Apply threshold override (treat as medium threshold)
     medium_threshold = threshold if threshold is not None else config.medium_overlap_threshold
 
-    # Load existing skills
     existing_skills = _load_existing_skills(existing_source)
-
-    # Exclude self-comparison
     existing_skills = [s for s in existing_skills if s.metadata.name != new_skill.metadata.name]
+
+    scores: list[tuple[ParsedSkill, float]]
+    if method == "tfidf":
+        scores = [
+            (
+                existing,
+                _tfidf_similarity(new_skill.metadata.description, existing.metadata.description),
+            )
+            for existing in existing_skills
+        ]
+    elif method == "embeddings":
+        scores = _embeddings_similarity(new_skill, existing_skills, config)
+    elif method == "llm":
+        scores = asyncio.run(_llm_similarity(new_skill, existing_skills, config))
+    else:
+        raise ConfigError(f"Unsupported conflict detection method: {method}")
 
     matches: list[ConflictMatch] = []
     name_collision = False
     name_collision_with = None
 
-    for existing in existing_skills:
-        # Name collision check
+    for existing, score in scores:
         if existing.metadata.name == new_skill.metadata.name:
             name_collision = True
             name_collision_with = existing.metadata.name
         else:
             ratio = _levenshtein_ratio(existing.metadata.name, new_skill.metadata.name)
-            if ratio >= 0.8:  # roughly equivalent to edit distance < 3 for short names
+            if ratio >= 0.8:
                 name_collision = True
                 name_collision_with = existing.metadata.name
-
-        score = _tfidf_similarity(new_skill.metadata.description, existing.metadata.description)
 
         if score < medium_threshold:
             continue
 
-        severity = "high" if score >= config.high_overlap_threshold else "medium"
+        if score >= config.high_overlap_threshold:
+            severity = "high"
+        elif score >= config.medium_overlap_threshold:
+            severity = "medium"
+        else:
+            severity = "low"
+
         overlap_phrases = _extract_overlap_phrases(
             new_skill.metadata.description, existing.metadata.description
         )
@@ -89,7 +103,7 @@ def compute_similarity(
             ConflictMatch(
                 existing_skill_name=existing.metadata.name,
                 similarity_score=round(score, 2),
-                severity=severity,  # type: ignore
+                severity=severity,
                 overlapping_phrases=overlap_phrases,
                 suggestions=suggestions,
             )
@@ -97,7 +111,6 @@ def compute_similarity(
 
     high_conflicts = sum(1 for m in matches if m.severity == "high")
     medium_conflicts = sum(1 for m in matches if m.severity == "medium")
-
     passed = not (config.block_on_high_overlap and high_conflicts > 0)
 
     return ConflictResult(
@@ -111,20 +124,132 @@ def compute_similarity(
     )
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _tfidf_similarity(text_a: str, text_b: str) -> float:
     vectorizer = TfidfVectorizer(ngram_range=(1, 2), stop_words="english")
     tfidf = vectorizer.fit_transform([text_a, text_b])
     return cosine_similarity(tfidf[0:1], tfidf[1:2])[0][0]
 
 
+def _embeddings_similarity(
+    new_skill: ParsedSkill,
+    existing_skills: list[ParsedSkill],
+    config: ConflictConfig,
+) -> list[tuple[ParsedSkill, float]]:
+    if not existing_skills:
+        return []
+
+    model = _load_sentence_transformer()
+    cache_dir = Path(config.embeddings_cache_dir)
+    new_embedding = _get_cached_embedding(
+        model, cache_dir, new_skill.metadata.name, new_skill.metadata.description
+    )
+
+    scores: list[tuple[ParsedSkill, float]] = []
+    for existing in existing_skills:
+        existing_embedding = _get_cached_embedding(
+            model, cache_dir, existing.metadata.name, existing.metadata.description
+        )
+        scores.append((existing, _cosine_similarity(new_embedding, existing_embedding)))
+    return scores
+
+
+def _load_sentence_transformer() -> Any:
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError as exc:
+        raise ConfigError(
+            "Embeddings extra not installed: pip install skill-guard[embeddings]"
+        ) from exc
+
+    return SentenceTransformer(_EMBEDDINGS_MODEL_NAME)
+
+
+def _get_cached_embedding(
+    model: Any, cache_dir: Path, skill_name: str, description: str
+) -> np.ndarray:
+    cache_file = cache_dir / f"{_embedding_cache_key(skill_name, description)}.json"
+    if cache_file.exists():
+        with cache_file.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return _normalize_embedding(np.asarray(payload["embedding"], dtype=float))
+
+    embedding = _normalize_embedding(np.asarray(model.encode(description), dtype=float))
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    with cache_file.open("w", encoding="utf-8") as handle:
+        json.dump({"embedding": embedding.tolist()}, handle)
+    return embedding
+
+
+def _embedding_cache_key(skill_name: str, description: str) -> str:
+    desc_hash = hashlib.sha256(description.encode("utf-8")).hexdigest()
+    safe_name = re.sub(r"[^a-zA-Z0-9_.-]+", "-", skill_name).strip("-") or "skill"
+    return f"{safe_name}-{desc_hash}"
+
+
+def _normalize_embedding(embedding: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(embedding)
+    if norm == 0:
+        return embedding
+    return embedding / norm
+
+
+def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    return float(np.dot(vec_a, vec_b))
+
+
+async def _llm_similarity(
+    new_skill: ParsedSkill,
+    existing_skills: list[ParsedSkill],
+    config: ConflictConfig,
+) -> list[tuple[ParsedSkill, float]]:
+    if not existing_skills:
+        return []
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ConfigError("OPENAI_API_KEY env var not set")
+
+    try:
+        from openai import AsyncOpenAI
+    except ImportError as exc:
+        raise ConfigError("LLM extra not installed: pip install skill-guard[llm]") from exc
+
+    client = AsyncOpenAI(api_key=api_key)
+    semaphore = asyncio.Semaphore(config.llm_max_concurrent)
+
+    async def _score(existing: ParsedSkill) -> tuple[ParsedSkill, float]:
+        async with semaphore:
+            prompt = _build_llm_prompt(
+                new_skill.metadata.description, existing.metadata.description
+            )
+            response = await asyncio.wait_for(
+                client.chat.completions.create(
+                    model=config.llm_model,
+                    messages=[{"role": "user", "content": prompt}],
+                ),
+                timeout=_LLM_TIMEOUT_SECONDS,
+            )
+            content = response.choices[0].message.content or ""
+            return existing, _parse_llm_score(content)
+
+    return list(await asyncio.gather(*(_score(existing) for existing in existing_skills)))
+
+
+def _build_llm_prompt(desc_a: str, desc_b: str) -> str:
+    return (
+        "Do these two agent skills overlap in purpose or trigger? Answer YES or NO only.\n\n"
+        f"Skill A: {desc_a}\n\n"
+        f"Skill B: {desc_b}"
+    )
+
+
+def _parse_llm_score(content: str) -> float:
+    answer = content.strip().upper()
+    return 0.85 if answer.startswith("YES") else 0.1
+
+
 def _extract_overlap_phrases(text_a: str, text_b: str) -> list[str]:
     """Extract overlapping phrases between two descriptions."""
-    # naive approach: shared bigrams
     tokens_a = _tokenize(text_a)
     tokens_b = _tokenize(text_b)
 
@@ -132,11 +257,19 @@ def _extract_overlap_phrases(text_a: str, text_b: str) -> list[str]:
     bigrams_b = set(zip(tokens_b, tokens_b[1:], strict=False))
 
     overlap = bigrams_a.intersection(bigrams_b)
-    phrases = [" ".join(b) for b in overlap]
+    phrases = [" ".join(bigram) for bigram in overlap]
+    phrases.extend(_extract_trigger_phrase(text_a, text_b))
 
-    # Return top 3 phrases by length
-    phrases = sorted(set(phrases), key=lambda s: (-len(s), s))
+    phrases = sorted(set(phrases), key=lambda value: (-len(value), value))
     return phrases[:3]
+
+
+def _extract_trigger_phrase(text_a: str, text_b: str) -> list[str]:
+    trigger_a = _TRIGGER_RE.search(text_a)
+    trigger_b = _TRIGGER_RE.search(text_b)
+    if not trigger_a or not trigger_b:
+        return []
+    return [trigger_a.group(0)] if trigger_a.group(0).lower() == trigger_b.group(0).lower() else []
 
 
 def _tokenize(text: str) -> list[str]:
@@ -164,11 +297,10 @@ def _load_existing_skills(source: Path) -> list[ParsedSkill]:
 
     if source.is_file() and source.suffix in (".yaml", ".yml"):
         yaml = YAML()
-        with open(source) as f:
-            raw = yaml.load(f)
+        with open(source, encoding="utf-8") as handle:
+            raw = yaml.load(handle)
         skills = []
         for entry in raw.get("skills", []):
-            # Create ParsedSkill-like object with only metadata
             meta = {
                 "name": entry.get("name"),
                 "description": entry.get("description"),
@@ -181,7 +313,7 @@ def _load_existing_skills(source: Path) -> list[ParsedSkill]:
             fake = ParsedSkill(
                 path=source,
                 skill_md_path=source,
-                metadata=meta,  # pydantic will coerce to SkillMetadata
+                metadata=meta,
                 body="",
                 body_line_count=0,
                 has_scripts=False,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,6 +15,9 @@ def test_load_config_defaults(tmp_path: Path):
         os.chdir(tmp_path)
         cfg = load_config()
         assert cfg.validate.min_description_length == 20
+        assert cfg.conflict.embeddings_cache_dir == ".skill-guard-cache/embeddings"
+        assert cfg.conflict.llm_model == "gpt-4o-mini"
+        assert cfg.conflict.llm_max_concurrent == 5
     finally:
         os.chdir(cwd)
 

--- a/tests/unit/test_similarity.py
+++ b/tests/unit/test_similarity.py
@@ -1,9 +1,15 @@
+import builtins
+import json
 import re
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from skill_guard.config import ConflictConfig
+from skill_guard.engine import similarity
 from skill_guard.engine.similarity import compute_similarity
 from skill_guard.models import ConfigError
 from skill_guard.parser import parse_skill
@@ -20,25 +26,158 @@ def test_conflict_high_overlap():
 def test_conflict_self_excluded():
     new_skill = parse_skill(FIXTURES / "valid-skill")
     result = compute_similarity(new_skill, FIXTURES, ConflictConfig())
-    # Should not conflict with itself
     assert all(m.existing_skill_name != "valid-skill" for m in result.matches)
 
 
+def test_embeddings_mode_uses_cache_and_cosine_similarity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    encode_calls: list[str] = []
+    cosine_calls: list[tuple[list[float], list[float]]] = []
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_name: str) -> None:
+            assert model_name == "all-MiniLM-L6-v2"
+
+        def encode(self, text: str) -> list[float]:
+            encode_calls.append(text)
+            if "weather" in text.lower():
+                return [1.0, 0.0]
+            return [0.8, 0.2]
+
+    def fake_cosine(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+        cosine_calls.append((vec_a.tolist(), vec_b.tolist()))
+        return float(np.dot(vec_a, vec_b))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        SimpleNamespace(SentenceTransformer=FakeSentenceTransformer),
+    )
+    monkeypatch.setattr(similarity, "_cosine_similarity", fake_cosine)
+
+    catalog_path = tmp_path / "catalog.yaml"
+    catalog_path.write_text(
+        (
+            "skills:\n"
+            "  - name: weather-helper\n"
+            "    description: Use when the user needs weather forecasts or current conditions.\n"
+        ),
+        encoding="utf-8",
+    )
+    config = ConflictConfig(
+        method="embeddings",
+        similarity_threshold=0.1,
+        embeddings_cache_dir=str(tmp_path / "embeddings-cache"),
+    )
+    new_skill = parse_skill(FIXTURES / "valid-skill")
+
+    first_result = compute_similarity(new_skill, catalog_path, config)
+    second_result = compute_similarity(new_skill, catalog_path, config)
+
+    assert first_result.matches
+    assert second_result.matches
+    assert len(encode_calls) == 2
+    assert cosine_calls
+
+    cache_files = sorted((tmp_path / "embeddings-cache").glob("*.json"))
+    assert len(cache_files) == 2
+    with cache_files[0].open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    assert "embedding" in payload
+
+
+def test_llm_mode_builds_prompt_and_parses_yes_no(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    prompts: list[str] = []
+
+    class FakeCompletions:
+        async def create(self, *, model: str, messages: list[dict[str, str]]):
+            assert model == "gpt-4o-mini"
+            assert messages[0]["role"] == "user"
+            prompt = messages[0]["content"]
+            prompts.append(prompt)
+            reply = "YES" if "email" in prompt.lower() else "NO"
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=reply))]
+            )
+
+    class FakeAsyncOpenAI:
+        def __init__(self, api_key: str) -> None:
+            assert api_key == "test-key"
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(AsyncOpenAI=FakeAsyncOpenAI))
+
+    catalog_path = tmp_path / "catalog.yaml"
+    catalog_path.write_text(
+        (
+            "skills:\n"
+            "  - name: email-helper\n"
+            "    description: Use when the user needs help drafting or editing email messages.\n"
+            "  - name: weather-helper\n"
+            "    description: Use when the user needs weather forecasts or current conditions.\n"
+        ),
+        encoding="utf-8",
+    )
+    config = ConflictConfig(method="llm", similarity_threshold=0.5)
+    new_skill = parse_skill(FIXTURES / "valid-skill")
+
+    result = compute_similarity(new_skill, catalog_path, config)
+
+    assert len(prompts) == 2
+    assert prompts[0].startswith(
+        "Do these two agent skills overlap in purpose or trigger? Answer YES or NO only."
+    )
+    assert "\n\nSkill A: " in prompts[0]
+    assert "\n\nSkill B: " in prompts[0]
+    assert [match.existing_skill_name for match in result.matches] == ["email-helper"]
+    assert result.matches[0].similarity_score == 0.85
+
+
 @pytest.mark.parametrize(
-    ("method", "message"),
+    ("method", "message", "env"),
     [
         (
             "embeddings",
-            "Embeddings conflict detection is not yet implemented. Use method: tfidf (default).",
+            "Embeddings extra not installed: pip install skill-guard[embeddings]",
+            {},
         ),
         (
             "llm",
-            "LLM conflict detection is not yet implemented. Use method: tfidf (default).",
+            "LLM extra not installed: pip install skill-guard[llm]",
+            {"OPENAI_API_KEY": "test-key"},
         ),
     ],
 )
-def test_conflict_unsupported_method_raises_config_error(method: str, message: str) -> None:
+def test_conflict_missing_optional_extra_raises_config_error(
+    method: str, message: str, env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name: str, *args, **kwargs):
+        if name in {"sentence_transformers", "openai"}:
+            raise ImportError("missing optional dependency")
+        return original_import(name, *args, **kwargs)
+
+    for key in ("OPENAI_API_KEY",):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
     new_skill = parse_skill(FIXTURES / "valid-skill")
 
     with pytest.raises(ConfigError, match=re.escape(message)):
         compute_similarity(new_skill, FIXTURES, ConflictConfig(method=method))
+
+
+def test_llm_mode_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    new_skill = parse_skill(FIXTURES / "valid-skill")
+
+    with pytest.raises(ConfigError, match="OPENAI_API_KEY env var not set"):
+        compute_similarity(new_skill, FIXTURES, ConflictConfig(method="llm"))


### PR DESCRIPTION
## Summary

Delivers the v0.6 scope promised in README and docs.

### What ships
- **Embeddings-based conflict detection** (`method: embeddings`) — uses `sentence-transformers` (`all-MiniLM-L6-v2`), normalized cosine similarity, on-disk caching in `.skill-guard-cache/embeddings/` (keyed by skill name + sha256 of description to avoid re-embedding on re-runs)
- **LLM-based conflict detection** (`method: llm`) — OpenAI Chat API (`gpt-4o-mini`), YES/NO prompt, async fan-out with configurable concurrency (default 5), 30s per-call timeout, uses `OPENAI_API_KEY`
- **Graceful missing-extra errors** — if `sentence-transformers` or `openai` not installed, raises `ConfigError` with install hint instead of ImportError
- **New optional extras** — `skill-guard[embeddings]` and `skill-guard[llm]`
- **New config fields** — `conflict.embeddings_cache_dir`, `conflict.llm_model`, `conflict.llm_max_concurrent`
- **Docs + changelog** — removed all 'planned for v0.6' notes, added Conflict Detection Modes section to README, updated configuration-reference.md

### Tests
- 4 new unit tests: embeddings cache/cosine, LLM prompt structure + YES/NO parsing, missing-extra ImportError (both modes), missing API key
- **100 passing, 82.97% coverage** (above 80% floor)
- ruff check + ruff format clean

### Version
`0.5.0` → `0.6.0`