### PR TITLE
feat: add repo-aware changed-skill checks

### DIFF
--- a/skill_guard/commands/check.py
+++ b/skill_guard/commands/check.py
@@ -3,29 +3,47 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 import warnings
 from pathlib import Path
 from typing import Any
 
 import typer
 
-from skill_guard.config import ConfigError, load_config
+from skill_guard.config import ConfigError, SkillGateConfig, load_config
 from skill_guard.engine.agent_runner import run_agent_tests
 from skill_guard.engine.quality import run_validation
+from skill_guard.engine.repo_targets import resolve_changed_skill_selection
 from skill_guard.engine.security import run_security_scan
 from skill_guard.engine.similarity import compute_similarity
-from skill_guard.models import HealthCheckTimeoutError, HookError, SkillParseError
+from skill_guard.models import (
+    CheckRunReport,
+    CheckSkillReport,
+    HealthCheckTimeoutError,
+    HookError,
+    SkillParseError,
+)
 from skill_guard.output.json_out import format_as_json
 from skill_guard.parser import parse_skill
 
-SKILL_PATH_ARG = typer.Argument(..., help="Path to skill directory")
-AGAINST_OPT = typer.Option(..., "--against", help="Skills dir or catalog YAML")
+TARGET_PATH_ARG = typer.Argument(
+    ...,
+    help="Path to a skill directory, or a skills root when used with --changed",
+)
+AGAINST_OPT = typer.Option(
+    None,
+    "--against",
+    help="Skills dir or catalog YAML. Defaults to the target parent, or the target root for --changed",
+)
 ENDPOINT_OPT = typer.Option(None, "--endpoint", help="Agent endpoint URL")
 CONFIG_OPT = typer.Option(None, "--config", help="Path to skill-guard.yaml")
 FORMAT_OPT = typer.Option(None, "--format", help="Output format: text|json|md")
+CHANGED_OPT = typer.Option(False, "--changed", help="Check all changed skills under TARGET_PATH")
+BASE_REF_OPT = typer.Option(None, "--base-ref", help="Base git ref used with --changed")
+HEAD_REF_OPT = typer.Option(None, "--head-ref", help="Head git ref used with --changed")
 
 
-def _emit(payload: dict[str, Any], output_format: str) -> None:
+def _emit_single(payload: dict[str, Any], output_format: str) -> None:
     if output_format == "json":
         typer.echo(format_as_json(payload, command="check"))
         return
@@ -49,145 +67,326 @@ def _emit(payload: dict[str, Any], output_format: str) -> None:
     )
 
 
-def check_cmd(
-    skill_path: Path = SKILL_PATH_ARG,
-    against: Path = AGAINST_OPT,
-    endpoint: str | None = ENDPOINT_OPT,
-    config_path: Path | None = CONFIG_OPT,
-    output_format: str | None = FORMAT_OPT,
-) -> None:
-    """Run validate + secure + conflict + test pipeline for a skill."""
-    try:
-        config = load_config(config_path)
-        skill = parse_skill(skill_path)
-    except ConfigError as e:
-        typer.echo(f"Config error: {e}")
-        raise typer.Exit(code=3) from e
-    except SkillParseError as e:
-        typer.echo(f"Parse error: {e}")
-        raise typer.Exit(code=4) from e
+def _emit_run(report: CheckRunReport, output_format: str) -> None:
+    if output_format == "json":
+        typer.echo(format_as_json(report, command="check"))
+        return
+    if output_format in ("md", "markdown"):
+        typer.echo(_format_markdown(report))
+        return
+    typer.echo(_format_text(report))
 
-    resolved_output_format = output_format or config.ci.output_format
-    if config.ci.post_pr_comment:
-        warnings.warn(
-            "ci.post_pr_comment is not yet implemented and has no effect.",
-            stacklevel=2,
+
+def _format_markdown(report: CheckRunReport) -> str:
+    rows = []
+    for skill in report.skills:
+        rows.append(
+            f"| {skill.skill_name} | {skill.target_status} | {skill.validation} | "
+            f"{skill.security} | {skill.conflict} | {skill.test} | {skill.status} |"
+        )
+
+    if not rows:
+        rows.append("| - | - | - | - | - | - | passed |")
+
+    return (
+        "## skill-guard check\n\n"
+        f"- mode: {report.mode}\n"
+        f"- target_root: {report.target_root}\n"
+        f"- against: {report.against}\n"
+        f"- total_skills: {report.total_skills}\n"
+        f"- checked_skills: {report.checked_skills}\n"
+        f"- skipped_skills: {report.skipped_skills}\n"
+        f"- passed: {report.passed}\n"
+        f"- warnings: {report.warnings}\n"
+        f"- failed: {report.failed}\n"
+        f"- status: {report.status}\n"
+        f"- summary: {report.summary}\n\n"
+        "| Skill | Change | Validation | Security | Conflict | Test | Status |\n"
+        "|---|---|---|---|---|---|---|\n"
+        + "\n".join(rows)
+    )
+
+
+def _format_text(report: CheckRunReport) -> str:
+    lines = [
+        f"mode={report.mode} status={report.status} total={report.total_skills} "
+        f"checked={report.checked_skills} skipped={report.skipped_skills}",
+        report.summary,
+    ]
+    for skill in report.skills:
+        lines.append(
+            f"- {skill.skill_name} [{skill.target_status}] "
+            f"validation={skill.validation} security={skill.security} "
+            f"conflict={skill.conflict} test={skill.test} status={skill.status}"
+        )
+    return "\n".join(lines)
+
+
+def _single_payload(report: CheckSkillReport) -> dict[str, Any]:
+    return {
+        "skill_name": report.skill_name,
+        "validation": report.validation,
+        "security": report.security,
+        "conflict": report.conflict,
+        "test": report.test,
+        "status": report.status,
+        "summary": report.summary,
+        "result": report.result,
+    }
+
+
+def _normalize_validation_for_target(
+    validation,
+    *,
+    skill_name: str,
+    target_status: str,
+    previous_skill_path: Path | None,
+):
+    if target_status != "renamed" or previous_skill_path is None:
+        return validation
+    if previous_skill_path.name != skill_name:
+        return validation
+
+    updated_checks = []
+    changed = False
+    for check in validation.checks:
+        if check.check_name == "directory_name_matches" and not check.passed:
+            updated_checks.append(
+                check.model_copy(
+                    update={
+                        "passed": True,
+                        "message": (
+                            "Directory rename accepted for changed-skill evaluation; "
+                            f"previous directory '{previous_skill_path.name}' matched skill name"
+                        ),
+                        "suggestion": None,
+                    }
+                )
+            )
+            changed = True
+            continue
+        updated_checks.append(check)
+
+    if not changed:
+        return validation
+
+    blockers = sum(1 for check in updated_checks if not check.passed and check.severity == "blocker")
+    warnings_count = sum(
+        1 for check in updated_checks if not check.passed and check.severity == "warning"
+    )
+    return validation.model_copy(
+        update={
+            "checks": updated_checks,
+            "passed": blockers == 0,
+            "blockers": blockers,
+            "warnings": warnings_count,
+        }
+    )
+
+
+def _run_skill_check(
+    skill_path: Path,
+    *,
+    against_source: Path,
+    endpoint: str | None,
+    config: SkillGateConfig,
+    target_status: str,
+    previous_skill_path: Path | None = None,
+) -> tuple[CheckSkillReport, int]:
+    try:
+        skill = parse_skill(skill_path)
+    except SkillParseError as exc:
+        return (
+            CheckSkillReport(
+                skill_name=skill_path.name,
+                skill_path=skill_path,
+                target_status=target_status,  # type: ignore[arg-type]
+                previous_skill_path=previous_skill_path,
+                validation="failed",
+                security="skipped",
+                conflict="skipped",
+                test="skipped",
+                status="failed",
+                summary=f"Parse error: {exc}",
+                result={},
+            ),
+            4,
         )
 
     validation = run_validation(skill, config.validate)
+    validation = _normalize_validation_for_target(
+        validation,
+        skill_name=skill.metadata.name,
+        target_status=target_status,
+        previous_skill_path=previous_skill_path,
+    )
+    validation_status = "passed" if validation.warnings == 0 else "warning"
     if validation.blockers > 0:
-        _emit(
-            {
-                "skill_name": skill.metadata.name,
-                "validation": "failed",
-                "security": "skipped",
-                "conflict": "skipped",
-                "test": "skipped",
-                "status": "failed",
-                "summary": f"Validation failed with {validation.blockers} blocker(s).",
-                "result": {
-                    "validation": validation.model_dump(mode="json"),
-                },
-            },
-            resolved_output_format,
+        return (
+            CheckSkillReport(
+                skill_name=skill.metadata.name,
+                skill_path=skill.path,
+                target_status=target_status,  # type: ignore[arg-type]
+                previous_skill_path=previous_skill_path,
+                validation="failed",
+                security="skipped",
+                conflict="skipped",
+                test="skipped",
+                status="failed",
+                summary=f"Validation failed with {validation.blockers} blocker(s).",
+                result={"validation": validation.model_dump(mode="json")},
+            ),
+            1,
         )
-        raise typer.Exit(code=1)
 
     security = run_security_scan(skill, config.secure)
     if not security.passed:
-        _emit(
-            {
-                "skill_name": skill.metadata.name,
-                "validation": "passed" if validation.warnings == 0 else "warning",
-                "security": "failed",
-                "conflict": "skipped",
-                "test": "skipped",
-                "status": "failed",
-                "summary": "Security scan failed.",
-                "result": {
+        return (
+            CheckSkillReport(
+                skill_name=skill.metadata.name,
+                skill_path=skill.path,
+                target_status=target_status,  # type: ignore[arg-type]
+                previous_skill_path=previous_skill_path,
+                validation=validation_status,
+                security="failed",
+                conflict="skipped",
+                test="skipped",
+                status="failed",
+                summary="Security scan failed.",
+                result={
                     "validation": validation.model_dump(mode="json"),
                     "security": security.model_dump(mode="json"),
                 },
-            },
-            resolved_output_format,
+            ),
+            1,
         )
-        raise typer.Exit(code=1)
+
     try:
-        conflict = compute_similarity(skill, against, config.conflict)
-    except ConfigError as e:
-        typer.echo(f"Config error: {e}")
-        raise typer.Exit(code=3) from e
+        conflict = compute_similarity(skill, against_source, config.conflict)
+    except ConfigError as exc:
+        return (
+            CheckSkillReport(
+                skill_name=skill.metadata.name,
+                skill_path=skill.path,
+                target_status=target_status,  # type: ignore[arg-type]
+                previous_skill_path=previous_skill_path,
+                validation=validation_status,
+                security="passed",
+                conflict="failed",
+                test="skipped",
+                status="failed",
+                summary=f"Config error: {exc}",
+                result={},
+            ),
+            3,
+        )
+
     if not conflict.passed:
-        _emit(
-            {
-                "skill_name": skill.metadata.name,
-                "validation": "passed" if validation.warnings == 0 else "warning",
-                "security": "passed",
-                "conflict": "failed",
-                "test": "skipped",
-                "status": "failed",
-                "summary": "Conflict detection found blocking overlap.",
-                "result": {
+        return (
+            CheckSkillReport(
+                skill_name=skill.metadata.name,
+                skill_path=skill.path,
+                target_status=target_status,  # type: ignore[arg-type]
+                previous_skill_path=previous_skill_path,
+                validation=validation_status,
+                security="passed",
+                conflict="failed",
+                test="skipped",
+                status="failed",
+                summary="Conflict detection found blocking overlap.",
+                result={
                     "validation": validation.model_dump(mode="json"),
                     "security": security.model_dump(mode="json"),
                     "conflict": conflict.model_dump(mode="json"),
                 },
-            },
-            resolved_output_format,
+            ),
+            1,
         )
-        raise typer.Exit(code=1)
 
-    resolved_endpoint = endpoint or config.test.endpoint
-    validation_status = "passed" if validation.warnings == 0 else "warning"
     test_status = "skipped"
     test_result = None
-    if resolved_endpoint:
-        config.test.endpoint = resolved_endpoint
+    if endpoint:
+        config.test.endpoint = endpoint
         try:
             test_result = asyncio.run(run_agent_tests(skill, config.test))
-        except HealthCheckTimeoutError as e:
-            typer.echo(f"Test setup error: {e}")
-            raise typer.Exit(code=6) from e
-        except HookError as e:
-            typer.echo(f"Test setup error: {e}")
-            raise typer.Exit(code=5) from e
+        except HealthCheckTimeoutError as exc:
+            return (
+                CheckSkillReport(
+                    skill_name=skill.metadata.name,
+                    skill_path=skill.path,
+                    target_status=target_status,  # type: ignore[arg-type]
+                    previous_skill_path=previous_skill_path,
+                    validation=validation_status,
+                    security="passed",
+                    conflict="passed",
+                    test="failed",
+                    status="failed",
+                    summary=f"Test setup error: {exc}",
+                    result={},
+                ),
+                6,
+            )
+        except HookError as exc:
+            return (
+                CheckSkillReport(
+                    skill_name=skill.metadata.name,
+                    skill_path=skill.path,
+                    target_status=target_status,  # type: ignore[arg-type]
+                    previous_skill_path=previous_skill_path,
+                    validation=validation_status,
+                    security="passed",
+                    conflict="passed",
+                    test="failed",
+                    status="failed",
+                    summary=f"Test setup error: {exc}",
+                    result={},
+                ),
+                5,
+            )
+
         if test_result.passed:
             test_status = "passed"
         elif test_result.failed_tests > 0:
-            _emit(
-                {
-                    "skill_name": skill.metadata.name,
-                    "validation": validation_status,
-                    "security": "passed",
-                    "conflict": "passed",
-                    "test": "failed",
-                    "status": "failed",
-                    "summary": "Agent evals failed with blocking failures.",
-                    "result": {
+            return (
+                CheckSkillReport(
+                    skill_name=skill.metadata.name,
+                    skill_path=skill.path,
+                    target_status=target_status,  # type: ignore[arg-type]
+                    previous_skill_path=previous_skill_path,
+                    validation=validation_status,
+                    security="passed",
+                    conflict="passed",
+                    test="failed",
+                    status="failed",
+                    summary="Agent evals failed with blocking failures.",
+                    result={
                         "validation": validation.model_dump(mode="json"),
                         "security": security.model_dump(mode="json"),
                         "conflict": conflict.model_dump(mode="json"),
                         "test": test_result.model_dump(mode="json"),
                     },
-                },
-                resolved_output_format,
+                ),
+                1,
             )
-            raise typer.Exit(code=1)
         else:
             test_status = "warning"
 
     has_warning = validation_status == "warning" or test_status == "warning"
     fail_on_warning = config.ci.fail_on_warning and has_warning
     final_status = "failed" if fail_on_warning else ("warning" if has_warning else "passed")
-    _emit(
-        {
-            "skill_name": skill.metadata.name,
-            "validation": validation_status,
-            "security": "passed",
-            "conflict": "passed",
-            "test": test_status,
-            "status": final_status,
-            "summary": (
+
+    return (
+        CheckSkillReport(
+            skill_name=skill.metadata.name,
+            skill_path=skill.path,
+            target_status=target_status,  # type: ignore[arg-type]
+            previous_skill_path=previous_skill_path,
+            validation=validation_status,
+            security="passed",
+            conflict="passed",
+            test=test_status,
+            status=final_status,  # type: ignore[arg-type]
+            summary=(
                 "All blocking checks passed."
                 if not has_warning
                 else (
@@ -196,19 +395,160 @@ def check_cmd(
                     else "Blocking checks passed with warnings."
                 )
             ),
-            "result": {
+            result={
                 "validation": validation.model_dump(mode="json"),
                 "security": security.model_dump(mode="json"),
                 "conflict": conflict.model_dump(mode="json"),
-                **(
-                    {"test": test_result.model_dump(mode="json")} if test_result is not None else {}
-                ),
+                **({"test": test_result.model_dump(mode="json")} if test_result is not None else {}),
             },
-        },
-        resolved_output_format,
+        ),
+        1 if fail_on_warning else (2 if has_warning else 0),
     )
 
-    if fail_on_warning:
-        raise typer.Exit(code=1)
-    if has_warning:
-        raise typer.Exit(code=2)
+
+def _build_run_report(
+    *,
+    mode: str,
+    target_root: Path,
+    against_source: Path,
+    skills: list[CheckSkillReport],
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+) -> CheckRunReport:
+    passed = sum(1 for skill in skills if skill.status == "passed")
+    warnings_count = sum(1 for skill in skills if skill.status == "warning")
+    failed = sum(1 for skill in skills if skill.status == "failed")
+    skipped = sum(1 for skill in skills if skill.status == "skipped")
+    checked = len(skills) - skipped
+
+    if failed > 0:
+        final_status = "failed"
+    elif warnings_count > 0:
+        final_status = "warning"
+    else:
+        final_status = "passed"
+
+    if not skills:
+        summary = "No changed skills detected."
+    elif checked == 0:
+        summary = f"No checkable changed skills. {skipped} skill(s) skipped."
+    else:
+        summary = (
+            f"{checked} skill(s) checked: {passed} passed, "
+            f"{warnings_count} warning, {failed} failed, {skipped} skipped."
+        )
+
+    return CheckRunReport(
+        mode=mode,  # type: ignore[arg-type]
+        target_root=target_root,
+        against=against_source,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        total_skills=len(skills),
+        checked_skills=checked,
+        skipped_skills=skipped,
+        passed=passed,
+        warnings=warnings_count,
+        failed=failed,
+        status=final_status,  # type: ignore[arg-type]
+        summary=summary,
+        skills=skills,
+    )
+
+
+def check_cmd(
+    target_path: Path = TARGET_PATH_ARG,
+    against: Path | None = AGAINST_OPT,
+    endpoint: str | None = ENDPOINT_OPT,
+    config_path: Path | None = CONFIG_OPT,
+    output_format: str | None = FORMAT_OPT,
+    changed: bool = CHANGED_OPT,
+    base_ref: str | None = BASE_REF_OPT,
+    head_ref: str | None = HEAD_REF_OPT,
+) -> None:
+    """Run validate + secure + conflict + test pipeline for one or more skills."""
+    try:
+        config = load_config(config_path)
+    except ConfigError as exc:
+        typer.echo(f"Config error: {exc}")
+        raise typer.Exit(code=3) from exc
+
+    resolved_output_format = output_format or config.ci.output_format
+    if config.ci.post_pr_comment:
+        warnings.warn(
+            "ci.post_pr_comment is not yet implemented and has no effect.",
+            stacklevel=2,
+        )
+
+    resolved_endpoint = endpoint or config.test.endpoint
+
+    if changed:
+        try:
+            selection = resolve_changed_skill_selection(
+                target_path,
+                base_ref=base_ref,
+                head_ref=head_ref,
+            )
+        except (ValueError, OSError, RuntimeError, subprocess.CalledProcessError) as exc:
+            typer.echo(f"Changed-skill detection error: {exc}")
+            raise typer.Exit(code=3) from exc
+
+        against_source = (against or selection.target_root).resolve()
+        reports: list[CheckSkillReport] = []
+        exit_code = 0
+
+        for target in selection.targets:
+            report, skill_exit = _run_skill_check(
+                target.root,
+                against_source=against_source,
+                endpoint=resolved_endpoint,
+                config=config,
+                target_status=target.status,
+                previous_skill_path=target.previous_root,
+            )
+            reports.append(report)
+            exit_code = max(exit_code, skill_exit)
+
+        for deleted_root in selection.deleted_roots:
+            reports.append(
+                CheckSkillReport(
+                    skill_name=deleted_root.name,
+                    skill_path=deleted_root,
+                    target_status="deleted",
+                    validation="skipped",
+                    security="skipped",
+                    conflict="skipped",
+                    test="skipped",
+                    status="skipped",
+                    summary="Skill was deleted in the compared diff.",
+                    result={},
+                )
+            )
+
+        run_report = _build_run_report(
+            mode="changed",
+            target_root=selection.target_root,
+            against_source=against_source,
+            skills=reports,
+            base_ref=selection.base_ref,
+            head_ref=selection.head_ref,
+        )
+        _emit_run(run_report, resolved_output_format)
+
+        if exit_code in (3, 4, 5, 6):
+            raise typer.Exit(code=exit_code)
+        if run_report.failed > 0:
+            raise typer.Exit(code=1)
+        return
+
+    against_source = (against or target_path.parent).resolve()
+    single_report, exit_code = _run_skill_check(
+        target_path,
+        against_source=against_source,
+        endpoint=resolved_endpoint,
+        config=config,
+        target_status="single",
+    )
+    _emit_single(_single_payload(single_report), resolved_output_format)
+    if exit_code != 0:
+        raise typer.Exit(code=exit_code)

--- a/skill_guard/commands/check.py
+++ b/skill_guard/commands/check.py
@@ -102,8 +102,7 @@ def _format_markdown(report: CheckRunReport) -> str:
         f"- status: {report.status}\n"
         f"- summary: {report.summary}\n\n"
         "| Skill | Change | Validation | Security | Conflict | Test | Status |\n"
-        "|---|---|---|---|---|---|---|\n"
-        + "\n".join(rows)
+        "|---|---|---|---|---|---|---|\n" + "\n".join(rows)
     )
 
 

--- a/skill_guard/commands/check.py
+++ b/skill_guard/commands/check.py
@@ -170,7 +170,9 @@ def _normalize_validation_for_target(
     if not changed:
         return validation
 
-    blockers = sum(1 for check in updated_checks if not check.passed and check.severity == "blocker")
+    blockers = sum(
+        1 for check in updated_checks if not check.passed and check.severity == "blocker"
+    )
     warnings_count = sum(
         1 for check in updated_checks if not check.passed and check.severity == "warning"
     )
@@ -399,7 +401,9 @@ def _run_skill_check(
                 "validation": validation.model_dump(mode="json"),
                 "security": security.model_dump(mode="json"),
                 "conflict": conflict.model_dump(mode="json"),
-                **({"test": test_result.model_dump(mode="json")} if test_result is not None else {}),
+                **(
+                    {"test": test_result.model_dump(mode="json")} if test_result is not None else {}
+                ),
             },
         ),
         1 if fail_on_warning else (2 if has_warning else 0),

--- a/skill_guard/commands/pre_commit.py
+++ b/skill_guard/commands/pre_commit.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import typer
 
 from skill_guard.config import ConfigError, load_config
+from skill_guard.engine.repo_targets import collect_skill_roots
 from skill_guard.engine.quality import run_validation
 from skill_guard.engine.security import run_security_scan
 from skill_guard.engine.similarity import compute_similarity
@@ -16,33 +17,6 @@ from skill_guard.models import SkillParseError
 from skill_guard.parser import parse_skill
 
 VALID_COMMANDS = {"validate", "secure", "check"}
-
-
-def find_skill_root(path: Path) -> Path | None:
-    """Walk up from a changed path until a skill root is found."""
-    candidate = path.resolve()
-    if candidate.is_file():
-        candidate = candidate.parent
-
-    for current in (candidate, *candidate.parents):
-        if (current / "SKILL.md").is_file():
-            return current
-    return None
-
-
-def collect_skill_roots(paths: Sequence[Path]) -> list[Path]:
-    """Resolve changed file paths to unique skill roots."""
-    roots: list[Path] = []
-    seen: set[Path] = set()
-    for path in paths:
-        root = find_skill_root(path)
-        if root is None or root in seen:
-            continue
-        seen.add(root)
-        roots.append(root)
-    return roots
-
-
 def _run_command(command: str, skill_root: Path) -> int:
     try:
         config = load_config()

--- a/skill_guard/commands/pre_commit.py
+++ b/skill_guard/commands/pre_commit.py
@@ -9,14 +9,16 @@ from pathlib import Path
 import typer
 
 from skill_guard.config import ConfigError, load_config
-from skill_guard.engine.repo_targets import collect_skill_roots
 from skill_guard.engine.quality import run_validation
+from skill_guard.engine.repo_targets import collect_skill_roots
 from skill_guard.engine.security import run_security_scan
 from skill_guard.engine.similarity import compute_similarity
 from skill_guard.models import SkillParseError
 from skill_guard.parser import parse_skill
 
 VALID_COMMANDS = {"validate", "secure", "check"}
+
+
 def _run_command(command: str, skill_root: Path) -> int:
     try:
         config = load_config()

--- a/skill_guard/engine/repo_targets.py
+++ b/skill_guard/engine/repo_targets.py
@@ -208,7 +208,9 @@ def _default_base_ref(repo_root: Path, head_ref: str) -> str:
     return "HEAD"
 
 
-def _git_diff_name_status(repo_root: Path, base_ref: str | None, head_ref: str) -> list[ChangedPath]:
+def _git_diff_name_status(
+    repo_root: Path, base_ref: str | None, head_ref: str
+) -> list[ChangedPath]:
     command = ["git", "diff", "--name-status", "-z"]
     if base_ref:
         command.append(f"{base_ref}...{head_ref}")

--- a/skill_guard/engine/repo_targets.py
+++ b/skill_guard/engine/repo_targets.py
@@ -1,0 +1,259 @@
+"""Helpers for resolving changed skill targets inside a repository."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ChangedPath:
+    """A single git diff path entry."""
+
+    status: str
+    old_path: Path | None
+    new_path: Path | None
+
+
+@dataclass(frozen=True)
+class ChangedSkillTarget:
+    """A skill root selected from repo changes."""
+
+    root: Path
+    status: str
+    changed_paths: tuple[Path, ...] = ()
+    previous_root: Path | None = None
+
+
+@dataclass(frozen=True)
+class ChangedSkillSelection:
+    """Resolved changed-skill selection for a repo-aware check run."""
+
+    repo_root: Path
+    target_root: Path
+    base_ref: str | None
+    head_ref: str | None
+    targets: tuple[ChangedSkillTarget, ...]
+    deleted_roots: tuple[Path, ...]
+
+
+def find_skill_root(path: Path) -> Path | None:
+    """Walk up from a path until a skill root is found."""
+    candidate = path.resolve()
+    if candidate.is_file():
+        candidate = candidate.parent
+
+    for current in (candidate, *candidate.parents):
+        if (current / "SKILL.md").is_file():
+            return current
+    return None
+
+
+def collect_skill_roots(paths: list[Path]) -> list[Path]:
+    """Resolve file paths to unique skill roots."""
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        root = find_skill_root(path)
+        if root is None or root in seen:
+            continue
+        seen.add(root)
+        roots.append(root)
+    return roots
+
+
+def resolve_changed_skill_selection(
+    target_root: Path,
+    *,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+) -> ChangedSkillSelection:
+    """Resolve changed skills under a target root from git diff output."""
+    repo_root = _git_repo_root(target_root)
+    resolved_target_root = target_root.resolve()
+    if not resolved_target_root.exists():
+        raise ValueError(f"Target path does not exist: {target_root}")
+    if not resolved_target_root.is_dir():
+        raise ValueError("Changed-skill detection requires a directory target.")
+
+    resolved_base = base_ref or _default_base_ref(repo_root, head_ref or "HEAD")
+    changed_paths = _git_diff_name_status(repo_root, resolved_base, head_ref or "HEAD")
+
+    targets_by_root: dict[Path, ChangedSkillTarget] = {}
+    deleted_roots: set[Path] = set()
+    target_root_rel = resolved_target_root.relative_to(repo_root)
+
+    for changed in changed_paths:
+        candidate_new = _resolve_candidate_root(
+            repo_root,
+            target_root_rel,
+            resolved_target_root,
+            changed.new_path,
+        )
+        candidate_old = _resolve_candidate_root(
+            repo_root,
+            target_root_rel,
+            resolved_target_root,
+            changed.old_path,
+        )
+
+        if changed.status.startswith("R") and candidate_new is not None:
+            previous_root = candidate_old or (
+                _infer_deleted_root(repo_root, target_root_rel, changed.old_path)
+                if changed.old_path is not None
+                else None
+            )
+            if previous_root == candidate_new:
+                previous_root = None
+            targets_by_root[candidate_new] = ChangedSkillTarget(
+                root=candidate_new,
+                status="renamed",
+                changed_paths=tuple(
+                    path for path in (changed.old_path, changed.new_path) if path is not None
+                ),
+                previous_root=previous_root,
+            )
+            continue
+
+        if candidate_new is not None:
+            existing = targets_by_root.get(candidate_new)
+            targets_by_root[candidate_new] = ChangedSkillTarget(
+                root=candidate_new,
+                status="modified",
+                changed_paths=_merge_paths(existing, changed.old_path, changed.new_path),
+                previous_root=existing.previous_root if existing is not None else None,
+            )
+            continue
+
+        if changed.status.startswith("D") and changed.old_path is not None:
+            deleted_root = _infer_deleted_root(repo_root, target_root_rel, changed.old_path)
+            if deleted_root is not None and deleted_root not in targets_by_root:
+                deleted_roots.add(deleted_root)
+
+    return ChangedSkillSelection(
+        repo_root=repo_root,
+        target_root=resolved_target_root,
+        base_ref=resolved_base,
+        head_ref=head_ref or "HEAD",
+        targets=tuple(sorted(targets_by_root.values(), key=lambda item: item.root.as_posix())),
+        deleted_roots=tuple(sorted(deleted_roots, key=lambda item: item.as_posix())),
+    )
+
+
+def _merge_paths(
+    existing: ChangedSkillTarget | None,
+    old_path: Path | None,
+    new_path: Path | None,
+) -> tuple[Path, ...]:
+    merged: list[Path] = list(existing.changed_paths) if existing is not None else []
+    for path in (old_path, new_path):
+        if path is not None and path not in merged:
+            merged.append(path)
+    return tuple(merged)
+
+
+def _resolve_candidate_root(
+    repo_root: Path,
+    target_root_rel: Path,
+    target_root: Path,
+    rel_path: Path | None,
+) -> Path | None:
+    if rel_path is None:
+        return None
+    try:
+        rel_path.relative_to(target_root_rel)
+    except ValueError:
+        return None
+    abs_path = (repo_root / rel_path).resolve()
+    if _is_relative_to(abs_path, target_root):
+        resolved_root = find_skill_root(abs_path)
+        if resolved_root is not None:
+            return resolved_root
+    return _infer_deleted_root(repo_root, target_root_rel, rel_path)
+
+
+def _infer_deleted_root(repo_root: Path, target_root_rel: Path, rel_path: Path) -> Path | None:
+    try:
+        relative_to_target = rel_path.relative_to(target_root_rel)
+    except ValueError:
+        return None
+    if not relative_to_target.parts:
+        return None
+    return repo_root / target_root_rel / relative_to_target.parts[0]
+
+
+def _git_repo_root(path: Path) -> Path:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=path.resolve(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _default_base_ref(repo_root: Path, head_ref: str) -> str:
+    for upstream in ("origin/HEAD", "origin/main", "origin/master"):
+        proc = subprocess.run(
+            ["git", "merge-base", upstream, head_ref],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    return "HEAD"
+
+
+def _git_diff_name_status(repo_root: Path, base_ref: str | None, head_ref: str) -> list[ChangedPath]:
+    command = ["git", "diff", "--name-status", "-z"]
+    if base_ref:
+        command.append(f"{base_ref}...{head_ref}")
+    else:
+        command.append(head_ref)
+
+    proc = subprocess.run(
+        command,
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    raw = proc.stdout.decode("utf-8", errors="replace")
+    if not raw:
+        return []
+
+    tokens = [token for token in raw.split("\x00") if token]
+    entries: list[ChangedPath] = []
+    index = 0
+    while index < len(tokens):
+        status = tokens[index]
+        index += 1
+        if status.startswith("R") or status.startswith("C"):
+            entries.append(
+                ChangedPath(
+                    status=status,
+                    old_path=Path(tokens[index]),
+                    new_path=Path(tokens[index + 1]),
+                )
+            )
+            index += 2
+            continue
+
+        path = Path(tokens[index])
+        index += 1
+        if status.startswith("D"):
+            entries.append(ChangedPath(status=status, old_path=path, new_path=None))
+        else:
+            entries.append(ChangedPath(status=status, old_path=None, new_path=path))
+    return entries
+
+
+def _is_relative_to(path: Path, other: Path) -> bool:
+    try:
+        path.relative_to(other)
+        return True
+    except ValueError:
+        return False

--- a/skill_guard/models.py
+++ b/skill_guard/models.py
@@ -300,6 +300,48 @@ class CheckPipelineResult(BaseModel):
     summary: str
 
 
+CheckStatus = Literal["passed", "warning", "failed", "skipped"]
+
+
+class CheckSkillReport(BaseModel):
+    """Per-skill report emitted by the repo-aware check command."""
+
+    skill_name: str
+    skill_path: Path
+    target_status: Literal["modified", "renamed", "deleted", "single"]
+    previous_skill_path: Path | None = None
+    validation: str
+    security: str
+    conflict: str
+    test: str
+    status: CheckStatus
+    summary: str
+    result: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class CheckRunReport(BaseModel):
+    """Aggregate report for a repo-aware `skill-guard check` run."""
+
+    mode: Literal["single", "changed"]
+    target_root: Path
+    against: Path
+    base_ref: str | None = None
+    head_ref: str | None = None
+    total_skills: int
+    checked_skills: int
+    skipped_skills: int
+    passed: int
+    warnings: int
+    failed: int
+    status: CheckStatus
+    summary: str
+    skills: list[CheckSkillReport]
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
 # ---------------------------------------------------------------------------
 # Catalog models
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_check_changed.py
+++ b/tests/integration/test_check_changed.py
@@ -40,7 +40,9 @@ def test_check_changed_reports_multi_skill_pr(tmp_path: Path, monkeypatch) -> No
 
     valid_skill = repo_root / "skills" / "valid-skill" / "SKILL.md"
     anthropic_skill = repo_root / "skills" / "anthropic-compliant" / "SKILL.md"
-    valid_skill.write_text(valid_skill.read_text(encoding="utf-8") + "\nExtra note.\n", encoding="utf-8")
+    valid_skill.write_text(
+        valid_skill.read_text(encoding="utf-8") + "\nExtra note.\n", encoding="utf-8"
+    )
     anthropic_skill.write_text(
         anthropic_skill.read_text(encoding="utf-8") + "\nExtra policy detail.\n",
         encoding="utf-8",

--- a/tests/integration/test_check_changed.py
+++ b/tests/integration/test_check_changed.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from skill_guard.main import app
+
+runner = CliRunner()
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "skills"
+
+
+def _run_git(args: list[str], cwd: Path) -> None:
+    env = {"TMPDIR": str(cwd)}
+    subprocess.run(["git", *args], cwd=cwd, env=env, check=True, capture_output=True, text=True)
+
+
+def _init_repo_with_skills(tmp_path: Path, skill_names: list[str]) -> Path:
+    repo_root = tmp_path / "repo"
+    skills_root = repo_root / "skills"
+    skills_root.mkdir(parents=True)
+
+    for skill_name in skill_names:
+        shutil.copytree(FIXTURES / skill_name, skills_root / skill_name)
+
+    _run_git(["init"], repo_root)
+    _run_git(["config", "user.name", "Test User"], repo_root)
+    _run_git(["config", "user.email", "test@example.com"], repo_root)
+    _run_git(["add", "."], repo_root)
+    _run_git(["commit", "-m", "initial"], repo_root)
+    return repo_root
+
+
+def test_check_changed_reports_multi_skill_pr(tmp_path: Path, monkeypatch) -> None:
+    repo_root = _init_repo_with_skills(tmp_path, ["valid-skill", "anthropic-compliant"])
+    monkeypatch.chdir(repo_root)
+
+    valid_skill = repo_root / "skills" / "valid-skill" / "SKILL.md"
+    anthropic_skill = repo_root / "skills" / "anthropic-compliant" / "SKILL.md"
+    valid_skill.write_text(valid_skill.read_text(encoding="utf-8") + "\nExtra note.\n", encoding="utf-8")
+    anthropic_skill.write_text(
+        anthropic_skill.read_text(encoding="utf-8") + "\nExtra policy detail.\n",
+        encoding="utf-8",
+    )
+    _run_git(["add", "."], repo_root)
+    _run_git(["commit", "-m", "modify skills"], repo_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(repo_root / "skills"),
+            "--changed",
+            "--base-ref",
+            "HEAD~1",
+            "--head-ref",
+            "HEAD",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code in (0, 2)
+    payload = json.loads(result.stdout)
+    report = payload["result"]
+    assert report["checked_skills"] == 2
+    assert report["failed"] == 0
+    assert report["status"] in ("passed", "warning")
+    assert {skill["skill_name"] for skill in report["skills"]} == {
+        "valid-skill",
+        "anthropic-compliant",
+    }
+
+
+def test_check_changed_handles_no_changes_cleanly(tmp_path: Path, monkeypatch) -> None:
+    repo_root = _init_repo_with_skills(tmp_path, ["valid-skill"])
+    monkeypatch.chdir(repo_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(repo_root / "skills"),
+            "--changed",
+            "--base-ref",
+            "HEAD",
+            "--head-ref",
+            "HEAD",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["result"]["summary"] == "No changed skills detected."
+    assert payload["result"]["skills"] == []
+
+
+def test_check_changed_handles_rename_and_delete(tmp_path: Path, monkeypatch) -> None:
+    repo_root = _init_repo_with_skills(tmp_path, ["valid-skill", "anthropic-compliant"])
+    monkeypatch.chdir(repo_root)
+
+    _run_git(["mv", "skills/valid-skill", "skills/valid-skill-renamed"], repo_root)
+    renamed_skill_md = repo_root / "skills" / "valid-skill-renamed" / "SKILL.md"
+    renamed_skill_md.write_text(
+        renamed_skill_md.read_text(encoding="utf-8").replace(
+            "name: valid-skill",
+            "name: valid-skill-renamed",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    shutil.rmtree(repo_root / "skills" / "anthropic-compliant")
+    _run_git(["add", "-A"], repo_root)
+    _run_git(["commit", "-m", "rename and delete"], repo_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(repo_root / "skills"),
+            "--changed",
+            "--base-ref",
+            "HEAD~1",
+            "--head-ref",
+            "HEAD",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    report = payload["result"]
+    assert report["checked_skills"] == 1
+    assert report["skipped_skills"] == 1
+
+    renamed = next(skill for skill in report["skills"] if skill["target_status"] == "renamed")
+    deleted = next(skill for skill in report["skills"] if skill["target_status"] == "deleted")
+    assert renamed["skill_name"] == "valid-skill-renamed"
+    assert renamed["previous_skill_path"].endswith("/skills/valid-skill")
+    assert deleted["skill_name"] == "anthropic-compliant"

--- a/tests/unit/test_repo_targets.py
+++ b/tests/unit/test_repo_targets.py
@@ -44,7 +44,9 @@ def test_resolve_changed_skill_selection_collects_modified_renamed_and_deleted(
         repo_targets,
         "_git_diff_name_status",
         lambda repo, base, head: [
-            repo_targets.ChangedPath(status="M", old_path=None, new_path=Path("skills/alpha/SKILL.md")),
+            repo_targets.ChangedPath(
+                status="M", old_path=None, new_path=Path("skills/alpha/SKILL.md")
+            ),
             repo_targets.ChangedPath(
                 status="R100",
                 old_path=Path("skills/beta/SKILL.md"),

--- a/tests/unit/test_repo_targets.py
+++ b/tests/unit/test_repo_targets.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import skill_guard.engine.repo_targets as repo_targets
+
+
+def test_collect_skill_roots_finds_unique_parents(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "alpha"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Use when resolving alpha tasks.\n---\n",
+        encoding="utf-8",
+    )
+
+    roots = repo_targets.collect_skill_roots(
+        [skill_dir / "SKILL.md", skill_dir / "references" / "guide.md"]
+    )
+
+    assert roots == [skill_dir.resolve()]
+
+
+def test_resolve_changed_skill_selection_collects_modified_renamed_and_deleted(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    skills_root = repo_root / "skills"
+    modified = skills_root / "alpha"
+    renamed = skills_root / "beta-renamed"
+    modified.mkdir(parents=True)
+    renamed.mkdir(parents=True)
+    (modified / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Use when resolving alpha tasks.\n---\n",
+        encoding="utf-8",
+    )
+    (renamed / "SKILL.md").write_text(
+        "---\nname: beta\ndescription: Use when resolving beta tasks.\n---\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(repo_targets, "_git_repo_root", lambda path: repo_root)
+    monkeypatch.setattr(repo_targets, "_default_base_ref", lambda repo, head: "base-sha")
+    monkeypatch.setattr(
+        repo_targets,
+        "_git_diff_name_status",
+        lambda repo, base, head: [
+            repo_targets.ChangedPath(status="M", old_path=None, new_path=Path("skills/alpha/SKILL.md")),
+            repo_targets.ChangedPath(
+                status="R100",
+                old_path=Path("skills/beta/SKILL.md"),
+                new_path=Path("skills/beta-renamed/SKILL.md"),
+            ),
+            repo_targets.ChangedPath(
+                status="D", old_path=Path("skills/gamma/SKILL.md"), new_path=None
+            ),
+        ],
+    )
+
+    selection = repo_targets.resolve_changed_skill_selection(skills_root)
+
+    assert selection.base_ref == "base-sha"
+    assert [target.status for target in selection.targets] == ["modified", "renamed"]
+    assert selection.targets[0].root == modified.resolve()
+    assert selection.targets[1].root == renamed.resolve()
+    assert selection.targets[1].previous_root == (skills_root / "beta").resolve()
+    assert selection.deleted_roots == ((skills_root / "gamma").resolve(),)


### PR DESCRIPTION
## Summary
- add repo-level changed-skill detection for git diff based check runs
- support aggregate multi-skill reporting in `skill-guard check --changed`
- cover no-change, rename, and delete scenarios with unit and integration tests

## Verification
- TMPDIR=/Users/vtupe/.openclaw/workspace/projects/skill-gate/repo/.tmp pytest --no-cov -q tests/unit/test_cli.py tests/unit/test_check_cmd.py tests/unit/test_pre_commit_cmd.py tests/unit/test_repo_targets.py tests/integration/test_pre_commit.py tests/integration/test_check_changed.py
- Result: 36 passed, 1 warning

## Issue
- closes #109