### PR TITLE
feat: add canonical GitHub PR gate workflow

### DIFF
--- a/.github/workflows/skill-guard-pr-gate.yml
+++ b/.github/workflows/skill-guard-pr-gate.yml
@@ -31,6 +31,17 @@ jobs:
         run: |
           set +e
 
+          if [ ! -d "skills" ]; then
+            echo "## skill-guard check" > skill-guard-summary.md
+            echo "" >> skill-guard-summary.md
+            echo "- status: passed" >> skill-guard-summary.md
+            echo "- summary: No top-level skills/ directory found; PR gate skipped." >> skill-guard-summary.md
+            printf '{\n  "command": "check",\n  "result": {\n    "status": "passed",\n    "summary": "No top-level skills/ directory found; PR gate skipped.",\n    "skills": []\n  }\n}\n' > skill-guard-report.json
+            cat skill-guard-summary.md >> "$GITHUB_STEP_SUMMARY"
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.sha }}"
 

--- a/.github/workflows/skill-guard-pr-gate.yml
+++ b/.github/workflows/skill-guard-pr-gate.yml
@@ -1,0 +1,70 @@
+name: skill-guard PR Gate
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "skill-guard.yaml"
+      - ".github/workflows/skill-guard-pr-gate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  skill-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install skill-guard
+        run: python -m pip install --upgrade pip && python -m pip install skill-guard
+
+      - name: Run repo-aware PR gate
+        id: skill_guard
+        shell: bash
+        run: |
+          set +e
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.sha }}"
+
+          skill-guard check skills/ \
+            --changed \
+            --base-ref "$BASE_SHA" \
+            --head-ref "$HEAD_SHA" \
+            --format md > skill-guard-summary.md
+          md_exit=$?
+
+          skill-guard check skills/ \
+            --changed \
+            --base-ref "$BASE_SHA" \
+            --head-ref "$HEAD_SHA" \
+            --format json > skill-guard-report.json
+          json_exit=$?
+
+          exit_code=$md_exit
+          if [ "$json_exit" -gt "$exit_code" ]; then
+            exit_code=$json_exit
+          fi
+
+          cat skill-guard-summary.md >> "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload PR gate artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-guard-pr-gate
+          path: |
+            skill-guard-summary.md
+            skill-guard-report.json
+
+      - name: Enforce skill-guard gate
+        if: steps.skill_guard.outputs.exit_code != '0'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -218,24 +218,31 @@ Use `skill-guard init --template base` to scaffold a new skill, or `skill-guard 
 ## GitHub Actions
 
 ```yaml
-- uses: vaibhavtupe/skill-guard-action@v1
-  with:
-    path: ./skills/my-skill
+name: skill-guard PR Gate
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+
+jobs:
+  skill-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install skill-guard
+      - run: |
+          skill-guard check skills/ \
+            --changed \
+            --base-ref "${{ github.event.pull_request.base.sha }}" \
+            --head-ref "${{ github.sha }}" \
+            --format md > skill-guard-summary.md
 ```
 
-See `vaibhavtupe/skill-guard-action` for the full action repo.
-
-## GitHub Actions
-
-Use the separate action repo `vaibhavtupe/skill-guard-action@v1` in workflows:
-
-```yaml
-- uses: vaibhavtupe/skill-guard-action@v1
-  with:
-    command: check
-    path: ./skills/my-skill
-    against: ./skills/
-```
+See [docs/ci-integration.md](docs/ci-integration.md) for the canonical workflow, JSON + markdown artifact strategy, and the checked-in example at [.github/workflows/skill-guard-pr-gate.yml](.github/workflows/skill-guard-pr-gate.yml).
 
 ## What skill-guard Does NOT Do
 

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -20,83 +20,85 @@ This guide covers integrating `skill-guard` into your CI/CD pipeline for automat
 
 ## Quickstart: GitHub Actions
 
-### Minimal CI workflow (validate + secure + conflict)
+### Canonical PR gate workflow
+
+The recommended PR gate is a single repo-aware `check --changed` run rooted at your skills directory.
+It evaluates every changed skill in the PR, writes a markdown summary for humans, writes JSON for machines,
+uploads both as artifacts, and fails the workflow only on blocking failures.
+
+This repo includes the canonical example at `.github/workflows/skill-guard-pr-gate.yml`:
 
 ```yaml
-# .github/workflows/skill-guard-ci.yml
-name: skill-guard CI
+name: skill-guard PR Gate
 
 on:
   pull_request:
     paths:
-      - 'skills/**'
+      - "skills/**"
+      - "skill-guard.yaml"
+
+permissions:
+  contents: read
 
 jobs:
   skill-guard:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install skill-guard
-        run: pip install skill-guard
-
-      - name: Validate skill
-        run: skill-guard validate skills/my-skill --format json
-
-      - name: Security scan
-        run: skill-guard secure skills/my-skill --format json
-
-      - name: Conflict check
-        run: skill-guard conflict skills/my-skill --against skills/ --format json
-```
-
-### Full pipeline with agent eval testing
-
-```yaml
-name: skill-guard Full CI
-
-on:
-  pull_request:
-    paths:
-      - 'skills/**'
-
-jobs:
-  skill-guard:
-    runs-on: ubuntu-latest
-    env:
-      AGENT_ENDPOINT: ${{ secrets.AGENT_ENDPOINT }}
-      AGENT_API_KEY: ${{ secrets.AGENT_API_KEY }}
-
-    steps:
-      - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
-      - name: Install skill-guard
-        run: pip install skill-guard
-
-      # Run the full pipeline in one command
-      - name: skill-guard check
+      - run: python -m pip install --upgrade pip && python -m pip install skill-guard
+      - id: skill_guard
+        shell: bash
         run: |
-          skill-guard check skills/my-skill \
-            --against skills/ \
-            --endpoint $AGENT_ENDPOINT \
-            --format json
+          set +e
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.sha }}"
+
+          skill-guard check skills/ \
+            --changed \
+            --base-ref "$BASE_SHA" \
+            --head-ref "$HEAD_SHA" \
+            --format md > skill-guard-summary.md
+          md_exit=$?
+
+          skill-guard check skills/ \
+            --changed \
+            --base-ref "$BASE_SHA" \
+            --head-ref "$HEAD_SHA" \
+            --format json > skill-guard-report.json
+          json_exit=$?
+
+          exit_code=$md_exit
+          if [ "$json_exit" -gt "$exit_code" ]; then
+            exit_code=$json_exit
+          fi
+
+          cat skill-guard-summary.md >> "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: skill-guard-pr-gate
+          path: |
+            skill-guard-summary.md
+            skill-guard-report.json
+      - if: steps.skill_guard.outputs.exit_code != '0'
+        run: exit 1
 ```
 
-Exit codes from `skill-guard check`:
-- `0` — all checks passed
-- `1` — a blocking check failed (validation, security, or conflict)
-- `2` — blocking checks passed but warnings present
+Exit codes from the PR-gate `skill-guard check --changed` flow:
+- `0` — no blocking failures in the changed skills
+- `1` — at least one changed skill hit a blocking failure
 - `3` — config error
 - `4` — skill parse error
+- `5` — test hook error
+- `6` — agent health/setup error
+
+Warnings remain in the markdown and JSON reports, but the canonical PR gate stays green unless
+`ci.fail_on_warning: true` promotes them to failures.
 
 ---
 
@@ -212,30 +214,23 @@ skill-guard conflict skills/pr-skill --against skill-catalog.yaml
 
 ## Output formats
 
-All commands support `--format text|json|md`. Use `json` in CI for structured parsing, `md` for PR comment annotations.
+All commands support `--format text|json|md`.
 
-### Posting results as a PR comment (GitHub Actions)
+For the canonical PR gate:
+- use `--format md` to produce a concise summary plus per-skill table for `GITHUB_STEP_SUMMARY`
+- use `--format json` to persist the full aggregate payload as an artifact for machine parsing
 
-```yaml
-- name: Run skill-guard check (JSON)
-  id: sg
-  run: |
-    skill-guard check skills/my-skill --against skills/ --format md > sg-report.md
-    echo "exit_code=$?" >> $GITHUB_OUTPUT
+The markdown contract is:
+- one run summary with mode, counts, final status, and a concise summary line
+- one per-skill table with change type plus validation/security/conflict/test/status columns
 
-- name: Comment on PR
-  uses: actions/github-script@v7
-  with:
-    script: |
-      const fs = require('fs');
-      const body = fs.readFileSync('sg-report.md', 'utf8');
-      github.rest.issues.createComment({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: context.issue.number,
-        body,
-      });
-```
+The JSON contract is:
+- top-level `command` and `timestamp`
+- aggregate `result` payload with run counts, final status, summary, and full per-skill detail
+
+If you want PR comments, post `skill-guard-summary.md` from the canonical workflow as-is.
+The primary path should not depend on shell glue like `git diff | head -1`; let `check --changed`
+resolve the skill set directly from the PR commit range.
 
 ---
 

--- a/skill_guard/commands/check.py
+++ b/skill_guard/commands/check.py
@@ -24,6 +24,7 @@ from skill_guard.models import (
     SkillParseError,
 )
 from skill_guard.output.json_out import format_as_json
+from skill_guard.output.markdown import format_as_markdown
 from skill_guard.parser import parse_skill
 
 TARGET_PATH_ARG = typer.Argument(
@@ -72,39 +73,9 @@ def _emit_run(report: CheckRunReport, output_format: str) -> None:
         typer.echo(format_as_json(report, command="check"))
         return
     if output_format in ("md", "markdown"):
-        typer.echo(_format_markdown(report))
+        typer.echo(format_as_markdown(report, command="check"))
         return
     typer.echo(_format_text(report))
-
-
-def _format_markdown(report: CheckRunReport) -> str:
-    rows = []
-    for skill in report.skills:
-        rows.append(
-            f"| {skill.skill_name} | {skill.target_status} | {skill.validation} | "
-            f"{skill.security} | {skill.conflict} | {skill.test} | {skill.status} |"
-        )
-
-    if not rows:
-        rows.append("| - | - | - | - | - | - | passed |")
-
-    return (
-        "## skill-guard check\n\n"
-        f"- mode: {report.mode}\n"
-        f"- target_root: {report.target_root}\n"
-        f"- against: {report.against}\n"
-        f"- total_skills: {report.total_skills}\n"
-        f"- checked_skills: {report.checked_skills}\n"
-        f"- skipped_skills: {report.skipped_skills}\n"
-        f"- passed: {report.passed}\n"
-        f"- warnings: {report.warnings}\n"
-        f"- failed: {report.failed}\n"
-        f"- status: {report.status}\n"
-        f"- summary: {report.summary}\n\n"
-        "| Skill | Change | Validation | Security | Conflict | Test | Status |\n"
-        "|---|---|---|---|---|---|---|\n" + "\n".join(rows)
-    )
-
 
 def _format_text(report: CheckRunReport) -> str:
     lines = [

--- a/skill_guard/commands/check.py
+++ b/skill_guard/commands/check.py
@@ -77,6 +77,7 @@ def _emit_run(report: CheckRunReport, output_format: str) -> None:
         return
     typer.echo(_format_text(report))
 
+
 def _format_text(report: CheckRunReport) -> str:
     lines = [
         f"mode={report.mode} status={report.status} total={report.total_skills} "

--- a/skill_guard/output/markdown.py
+++ b/skill_guard/output/markdown.py
@@ -101,6 +101,5 @@ def _check_run_md(result: CheckRunReport) -> str:
         f"- status: {result.status}\n"
         f"- summary: {result.summary}\n\n"
         "| Skill | Change | Validation | Security | Conflict | Test | Status |\n"
-        "|---|---|---|---|---|---|---|\n"
-        + "\n".join(rows)
+        "|---|---|---|---|---|---|---|\n" + "\n".join(rows)
     )

--- a/skill_guard/output/markdown.py
+++ b/skill_guard/output/markdown.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from skill_guard.models import ConflictResult, SecurityResult, ValidationResult
+from skill_guard.models import CheckRunReport, ConflictResult, SecurityResult, ValidationResult
 
 
 def format_as_markdown(result: Any, command: str = "") -> str:
@@ -14,6 +14,8 @@ def format_as_markdown(result: Any, command: str = "") -> str:
         return _security_md(result)
     if isinstance(result, ConflictResult):
         return _conflict_md(result)
+    if isinstance(result, CheckRunReport):
+        return _check_run_md(result)
     return f"## skill-guard result\n\n``\n{result}\n``"
 
 
@@ -71,4 +73,34 @@ def _conflict_md(result: ConflictResult) -> str:
     return (
         f"## skill-guard conflict — `{result.skill_name}`\n\n"
         f"| Skill | Severity | Score |\n|---|---|---|\n" + "\n".join(rows)
+    )
+
+
+def _check_run_md(result: CheckRunReport) -> str:
+    rows = []
+    for skill in result.skills:
+        rows.append(
+            f"| {skill.skill_name} | {skill.target_status} | {skill.validation} | "
+            f"{skill.security} | {skill.conflict} | {skill.test} | {skill.status} |"
+        )
+
+    if not rows:
+        rows.append("| - | - | - | - | - | - | passed |")
+
+    return (
+        "## skill-guard check\n\n"
+        f"- mode: {result.mode}\n"
+        f"- target_root: {result.target_root}\n"
+        f"- against: {result.against}\n"
+        f"- total_skills: {result.total_skills}\n"
+        f"- checked_skills: {result.checked_skills}\n"
+        f"- skipped_skills: {result.skipped_skills}\n"
+        f"- passed: {result.passed}\n"
+        f"- warnings: {result.warnings}\n"
+        f"- failed: {result.failed}\n"
+        f"- status: {result.status}\n"
+        f"- summary: {result.summary}\n\n"
+        "| Skill | Change | Validation | Security | Conflict | Test | Status |\n"
+        "|---|---|---|---|---|---|---|\n"
+        + "\n".join(rows)
     )

--- a/tests/integration/test_check_changed.py
+++ b/tests/integration/test_check_changed.py
@@ -65,7 +65,7 @@ def test_check_changed_reports_multi_skill_pr(tmp_path: Path, monkeypatch) -> No
         ],
     )
 
-    assert result.exit_code in (0, 2)
+    assert result.exit_code == 0
     payload = json.loads(result.stdout)
     report = payload["result"]
     assert report["checked_skills"] == 2

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,8 +1,13 @@
+import json
 from pathlib import Path
 
-import json
-
-from skill_guard.models import CheckResult, CheckRunReport, CheckSkillReport, ConflictResult, ValidationResult
+from skill_guard.models import (
+    CheckResult,
+    CheckRunReport,
+    CheckSkillReport,
+    ConflictResult,
+    ValidationResult,
+)
 from skill_guard.output.json_out import format_as_json
 from skill_guard.output.markdown import format_as_markdown
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from skill_guard.models import CheckResult, ConflictResult, ValidationResult
+import json
+
+from skill_guard.models import CheckResult, CheckRunReport, CheckSkillReport, ConflictResult, ValidationResult
 from skill_guard.output.json_out import format_as_json
 from skill_guard.output.markdown import format_as_markdown
 
@@ -31,3 +33,84 @@ def test_markdown_output():
     )
     md = format_as_markdown(conflict, command="conflict")
     assert "skill-guard conflict" in md
+
+
+def test_json_output_supports_aggregate_check_report():
+    report = CheckRunReport(
+        mode="changed",
+        target_root=Path("/tmp/skills"),
+        against=Path("/tmp/skills"),
+        total_skills=2,
+        checked_skills=1,
+        skipped_skills=1,
+        passed=1,
+        warnings=0,
+        failed=0,
+        status="passed",
+        summary="1 skill checked, 1 skipped.",
+        skills=[
+            CheckSkillReport(
+                skill_name="alpha",
+                skill_path=Path("/tmp/skills/alpha"),
+                target_status="modified",
+                validation="passed",
+                security="passed",
+                conflict="passed",
+                test="skipped",
+                status="passed",
+                summary="All blocking checks passed.",
+            ),
+            CheckSkillReport(
+                skill_name="beta",
+                skill_path=Path("/tmp/skills/beta"),
+                target_status="deleted",
+                validation="skipped",
+                security="skipped",
+                conflict="skipped",
+                test="skipped",
+                status="skipped",
+                summary="Skill was deleted in the compared diff.",
+            ),
+        ],
+    )
+
+    out = format_as_json(report, command="check")
+    payload = json.loads(out)
+
+    assert payload["command"] == "check"
+    assert payload["result"]["mode"] == "changed"
+    assert payload["result"]["skills"][1]["target_status"] == "deleted"
+
+
+def test_markdown_output_supports_aggregate_check_report():
+    report = CheckRunReport(
+        mode="changed",
+        target_root=Path("/tmp/skills"),
+        against=Path("/tmp/skills"),
+        total_skills=1,
+        checked_skills=1,
+        skipped_skills=0,
+        passed=1,
+        warnings=0,
+        failed=0,
+        status="passed",
+        summary="1 skill checked: 1 passed, 0 warning, 0 failed, 0 skipped.",
+        skills=[
+            CheckSkillReport(
+                skill_name="alpha",
+                skill_path=Path("/tmp/skills/alpha"),
+                target_status="modified",
+                validation="passed",
+                security="passed",
+                conflict="passed",
+                test="skipped",
+                status="passed",
+                summary="All blocking checks passed.",
+            )
+        ],
+    )
+
+    md = format_as_markdown(report, command="check")
+
+    assert "## skill-guard check" in md
+    assert "| alpha | modified | passed | passed | passed | skipped | passed |" in md


### PR DESCRIPTION
## Summary
- add one canonical GitHub Actions PR-gate workflow around `skill-guard check --changed`
- move aggregate markdown output into the shared formatter and cover JSON/markdown contracts with tests
- rewrite CI docs and README to match the shipped repo-aware workflow exactly

## Verification
- TMPDIR=/Users/vtupe/.openclaw/workspace/projects/skill-gate/repo/.tmp pytest --no-cov -q tests/unit/test_output.py tests/unit/test_check_cmd.py tests/integration/test_check_changed.py
- Result: 13 passed

## Issue
- closes #110