### PR TITLE
fix: align eval specs and placeholder docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
-skill-guard is a CLI tool that validates, secures, and governs [Agent Skills](https://agentskills.io) across their full lifecycle — from contribution to production monitoring.
+skill-guard is a CLI tool that validates, secures, and checks [Agent Skills](https://agentskills.io), with the default workflow centered on pre-merge repository gates.
 
 ## The Problem
 
@@ -29,9 +29,9 @@ ONBOARDING (pre-merge, in CI):
   skill-guard test       → runs evals against an OpenAI-compatible endpoint. Supports injection methods: custom_hook (pre/post scripts), directory_copy, and git_push.
   skill-guard check      → runs validate + secure + conflict as a single gate. Agent evals run if --endpoint is configured.
 
-ONGOING (post-merge, scheduled):
-  skill-guard monitor    → re-run evals, detect drift, manage lifecycle. Run via cron or CI for continuous drift detection. No built-in scheduler.
-  skill-guard catalog    → searchable registry of registered skills (approval workflow planned for v0.7)
+OPTIONAL / NON-DEFAULT:
+  skill-guard monitor    → re-run evals and lifecycle checks on a schedule. Run via cron or CI. No built-in scheduler.
+  skill-guard catalog    → maintain a YAML skill catalog. Approval workflow is not implemented in the CLI.
 ```
 
 ## Quick Start
@@ -99,7 +99,7 @@ $ skill-guard validate ./skills/my-skill/
 │ description_trigger_hint  │ ✅ Description contains trigger hint ('Use when')│
 │ no_broken_body_paths      │ ✅ No broken relative paths in SKILL.md body     │
 │ evals_directory_exists    │ ⚠️ No evals/ directory found                     │
-│                           │ → Create evals/config.yaml with test cases       │
+│                           │ → Create evals/evals.json or evals/config.yaml   │
 │ metadata_has_author       │ ✅ author: my-team                               │
 │ metadata_has_version      │ ✅ version: 1.0                                  │
 └───────────────────────────┴──────────────────────────────────────────────────┘
@@ -213,7 +213,7 @@ These hooks run against changed `SKILL.md` files, deduplicate by skill root, and
 
 ## Templates
 
-Use `skill-guard init --template base` to scaffold a new skill, or `skill-guard init --list-templates` to see the available scaffolds. Generated templates include `SKILL.md`, `evals/`, `references/`, `scripts/`, and `assets/` so they validate immediately.
+Use `skill-guard init --template base` to scaffold a new skill, or `skill-guard init --list-templates` to see the available scaffolds. Generated templates include `SKILL.md`, `evals/evals.json`, `references/`, `scripts/`, and `assets/` so they validate immediately.
 
 ## GitHub Actions
 

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -123,7 +123,7 @@ my-skill/
         └── edge-case.md
 ```
 
-Use one format per skill. If both exist, `evals.json` takes precedence; `config.yaml`-only setups may emit a validation warning about missing `evals.json`.
+`evals/evals.json` is the canonical format. `config.yaml` remains supported for prompt-file workflows. If both exist, `evals.json` takes precedence; `config.yaml`-only setups may emit an Anthropic-spec warning about missing `evals.json`.
 
 2. `evals/config.yaml` format:
 
@@ -258,10 +258,10 @@ See [configuration-reference.md](configuration-reference.md) for all `skill-guar
 
 ---
 
-## Versioning
+## Scope note
 
-| Version | Phase | Key additions |
-|---|---|---|
-| `0.1.x` | Phase 1 | `validate`, `secure`, `conflict`, `init` |
-| `0.2.x` | Phase 2 | `test`, `catalog`, `check`, integration testing, this guide |
-| `0.3.x` | Phase 3 | `monitor`, Slack/GitHub notifications, auto-stage transitions |
+This guide covers the shipped CI paths in the repo today:
+- the default PR gate around `skill-guard check --changed`
+- optional live eval runs with `skill-guard test`
+
+Monitoring and notification workflows exist in the CLI, but they are not part of the default v0.8 PR-gate path.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -16,6 +16,7 @@ validate:
   require_author_in_metadata: true
   require_version_in_metadata: true
   require_evals: false
+  anthropic_spec: true
   vague_phrases:
     - "a useful skill"
 
@@ -30,6 +31,7 @@ secure:
       file: scripts/setup.sh
 
 conflict:
+  similarity_threshold: 0.70
   method: tfidf
   high_overlap_threshold: 0.75
   medium_overlap_threshold: 0.55
@@ -40,14 +42,23 @@ conflict:
   llm_model: gpt-4o-mini
   llm_max_concurrent: 5
 
+test:
+  baseline: false
+  workspace_dir: ./eval-workspace
+
 monitor:
   stale_threshold_days: 180
   degrade_after_failures: 7
   deprecate_after_failures: 30
+  notify:
+    slack_webhook: ${SLACK_WEBHOOK_URL}
+    github_issues: false
+    github_token: ${GITHUB_TOKEN}
+    github_repo: owner/repo
 
 ci:
   fail_on_warning: false
-  post_pr_comment: false  # reserved for future GitHub integration
+  post_pr_comment: false  # experimental placeholder; no PR comment posting yet
   output_format: markdown
 ```
 
@@ -67,16 +78,18 @@ Path to `skill-catalog.yaml`. Default: `./skill-catalog.yaml`
 - `require_author_in_metadata` (bool, default true)
 - `require_version_in_metadata` (bool, default true)
 - `require_evals` (bool, default false)
+- `anthropic_spec` (bool, default true)
 - `vague_phrases` (list[str]) additional phrases to flag
 
 ### `secure.*`
 - `block_on` (list[str]) severities that cause failure (critical/high/medium/low)
 - `allow_external_urls_in_scripts` (bool)
 - `skip_references` (bool) skip scanning references/ files for injection patterns
-- `use_snyk_scan` (bool, reserved for future integration)
+- `use_snyk_scan` (bool, experimental placeholder; no snyk CLI integration yet)
 - `allow_list` (list) suppress specific findings
 
 ### `conflict.*`
+- `similarity_threshold` (float, default `0.70`) legacy overall threshold used when a command asks for one threshold value
 - `method` (`tfidf`|`embeddings`|`llm`)
 - `high_overlap_threshold` (float)
 - `medium_overlap_threshold` (float)
@@ -94,6 +107,7 @@ Path to `skill-catalog.yaml`. Default: `./skill-catalog.yaml`
 - `api_key` (string, optional)
 - `model` (string, optional)
 - `timeout_seconds` (int, default 30)
+- `baseline` (bool, default false) run a second no-injection eval pass for comparison
 - `workspace_dir` (string, optional) write AgentSkills eval artifacts
 - `reload_command` (string, optional)
 - `reload_wait_seconds` (int)
@@ -112,11 +126,15 @@ Path to `skill-catalog.yaml`. Default: `./skill-catalog.yaml`
 - `stale_threshold_days` (int)
 - `degrade_after_failures` (int; `degrade_after_days` still loads as a deprecated alias)
 - `deprecate_after_failures` (int; `deprecate_after_days` still loads as a deprecated alias)
+- `notify.slack_webhook` (string, optional)
+- `notify.github_issues` (bool, default false)
+- `notify.github_token` (string, optional)
+- `notify.github_repo` (string, optional)
 - Run via cron or CI for continuous drift detection. No built-in scheduler.
 
 ### `ci.*`
 - `fail_on_warning` (bool)
-- `post_pr_comment` (bool, reserved for future integration)
+- `post_pr_comment` (bool, experimental placeholder; no GitHub PR comment support in the CLI yet)
 - `output_format` (text|json|markdown)
 
 ## Environment Variables

--- a/docs/eval-authoring-guide.md
+++ b/docs/eval-authoring-guide.md
@@ -20,7 +20,7 @@ my-skill/
         └── out-of-scope.md
 ```
 
-Use one format per skill. If both `evals.json` and `config.yaml` exist, `evals.json` takes precedence. If you only use `config.yaml`, you'll see a validation warning about missing `evals.json` — safe to ignore, or add a minimal `evals.json` stub if you want a clean validation report.
+`evals/evals.json` is the canonical format. `config.yaml` is still supported for prompt-file workflows. If both `evals.json` and `config.yaml` exist, `evals.json` takes precedence. If you only use `config.yaml`, Anthropic-spec validation may warn about missing `evals.json` — safe to ignore if you intentionally use the YAML format.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,4 +61,4 @@ Suggestions: merge, narrow, exclude hints
 ## Next
 
 - See [Configuration Reference](configuration-reference.md)
-- Add evals in `evals/` for Phase 2 integration tests
+- Add evals in `evals/` if you want optional live eval coverage with `skill-guard test`

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -72,7 +72,7 @@ skills/my-skill/
         └── out-of-scope.md # negative test — skill should NOT trigger
 ```
 
-Use one format per skill. If both exist, `evals.json` takes precedence; `config.yaml`-only setups may emit a validation warning about missing `evals.json`.
+`evals/evals.json` is the canonical format. `config.yaml` remains supported for prompt-file workflows. If both exist, `evals.json` takes precedence; `config.yaml`-only setups may emit an Anthropic-spec warning about missing `evals.json`.
 
 `evals/config.yaml`:
 ```yaml

--- a/skill_guard/config.py
+++ b/skill_guard/config.py
@@ -317,6 +317,7 @@ secure:
 # Conflict detection (skill-guard conflict)
 # ─────────────────────────────────────────────
 conflict:
+  similarity_threshold: 0.70      # Legacy overall threshold; medium/high thresholds below drive richer output
   method: tfidf                    # tfidf | embeddings | llm
   high_overlap_threshold: 0.75    # >= this = HIGH conflict
   medium_overlap_threshold: 0.55  # >= this = MEDIUM conflict
@@ -327,7 +328,7 @@ conflict:
   # Tip: add conflict_ignore in SKILL.md frontmatter to skip specific skills
 
 # ─────────────────────────────────────────────
-# Integration testing (skill-guard test) — Phase 2
+# Live eval configuration (optional; not required for the default PR gate)
 # ─────────────────────────────────────────────
 # test:
 #   endpoint: ${AGENT_API_ENDPOINT}
@@ -354,7 +355,7 @@ conflict:
 #     # git_commit_message: "skill-guard test injection"
 
 # ─────────────────────────────────────────────
-# Monitoring — Phase 3
+# Monitoring (optional lifecycle workflow; not part of the default PR gate)
 # ─────────────────────────────────────────────
 # monitor:
 #   stale_threshold_days: 180
@@ -368,6 +369,6 @@ conflict:
 # ─────────────────────────────────────────────
 ci:
   fail_on_warning: false
-  post_pr_comment: false           # Reserved for future GitHub PR comment support
+  post_pr_comment: false           # Experimental placeholder; no GitHub PR comment support yet
   output_format: markdown
 """

--- a/skill_guard/engine/quality.py
+++ b/skill_guard/engine/quality.py
@@ -334,7 +334,7 @@ def run_validation(skill: ParsedSkill, config: ValidateConfig) -> ValidationResu
                 severity=evals_severity,
                 message="No evals/ directory found",
                 suggestion=(
-                    "Create evals/config.yaml with test cases. "
+                    "Create evals/evals.json (preferred) or evals/config.yaml with test cases. "
                     "Required for integration testing (skill-guard test). "
                     "See docs/eval-authoring-guide.md"
                 ),

--- a/skill_guard/parser.py
+++ b/skill_guard/parser.py
@@ -172,20 +172,16 @@ def _parse_evals_config(evals_dir: Path) -> EvalConfig:
     config_path = evals_dir / "config.yaml"
     evals_json_path = evals_dir / "evals.json"
 
-    evals_json_config: EvalConfig | None = None
     if evals_json_path.exists():
-        evals_json_config = _parse_evals_json(evals_json_path, evals_dir)
+        return _parse_evals_json(evals_json_path, evals_dir)
 
     if config_path.exists():
         return _parse_evals_yaml(config_path, evals_dir)
 
-    if evals_json_config is not None:
-        return evals_json_config
-
     raise SkillParseError(
         f"evals/config.yaml not found in '{evals_dir.parent}'\n"
-        f"  → Create evals/config.yaml with test case definitions\n"
-        f"  → See docs/eval-authoring-guide.md for the format"
+        f"  → Create evals/evals.json (preferred) or evals/config.yaml with test case definitions\n"
+        f"  → See docs/eval-authoring-guide.md for the supported formats"
     )
 
 

--- a/tests/fixtures/skills/valid-skill/evals/evals.json
+++ b/tests/fixtures/skills/valid-skill/evals/evals.json
@@ -3,8 +3,31 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Diagnose latency spikes between services.",
-      "expected_output": "Structured troubleshooting guidance for a network connectivity issue."
+      "name": "basic-usage",
+      "prompt": "My AWS connection keeps dropping packets. Can you help diagnose?",
+      "expect": {
+        "contains": ["diagnostic", "latency"],
+        "not_contains": ["I cannot", "error"]
+      },
+      "expected_output": "Diagnostic guidance for packet loss or latency issues."
+    },
+    {
+      "id": 2,
+      "name": "edge-case",
+      "prompt": "Connection reports 0.01% packet loss. Is that normal?",
+      "expect": {
+        "contains": ["no active connections found"]
+      },
+      "expected_output": "Guidance about whether the packet loss level is significant."
+    },
+    {
+      "id": 3,
+      "name": "not-my-job",
+      "prompt": "Create a new Azure connection in US-East.",
+      "expect": {
+        "not_contains": ["diagnostic", "traceroute", "packet loss"]
+      },
+      "expected_output": "A refusal or redirect because the request is out of scope."
     }
   ]
 }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -56,3 +56,40 @@ def test_monitor_failure_aliases_load_from_legacy_keys(tmp_path: Path) -> None:
 
     assert cfg.monitor.degrade_after_failures == 3
     assert cfg.monitor.deprecate_after_failures == 9
+
+
+def test_documented_config_fields_load(tmp_path: Path) -> None:
+    config_file = tmp_path / "skill-guard.yaml"
+    config_file.write_text(
+        (
+            "validate:\n"
+            "  anthropic_spec: false\n"
+            "secure:\n"
+            "  use_snyk_scan: true\n"
+            "conflict:\n"
+            "  similarity_threshold: 0.82\n"
+            "test:\n"
+            "  baseline: true\n"
+            "  workspace: ./eval-artifacts\n"
+            "monitor:\n"
+            "  notify:\n"
+            "    github_issues: true\n"
+            "    github_token: token\n"
+            "    github_repo: owner/repo\n"
+            "ci:\n"
+            "  post_pr_comment: true\n"
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(config_file)
+
+    assert cfg.validate.anthropic_spec is False
+    assert cfg.secure.use_snyk_scan is True
+    assert cfg.conflict.similarity_threshold == 0.82
+    assert cfg.test.baseline is True
+    assert cfg.test.workspace_dir == "./eval-artifacts"
+    assert cfg.monitor.notify.github_issues is True
+    assert cfg.monitor.notify.github_token == "token"
+    assert cfg.monitor.notify.github_repo == "owner/repo"
+    assert cfg.ci.post_pr_comment is True

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -41,6 +41,40 @@ def test_parse_evals_json_only():
     assert skill.evals_config.tests[0].prompt is not None
 
 
+def test_parse_evals_json_takes_precedence_over_yaml(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "precedence-skill"
+    evals_dir = skill_dir / "evals"
+    prompts_dir = evals_dir / "prompts"
+    prompts_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        '---\nname: precedence-skill\ndescription: "Use when eval precedence must be verified."\n---\n',
+        encoding="utf-8",
+    )
+    (prompts_dir / "yaml.md").write_text("yaml prompt", encoding="utf-8")
+    (evals_dir / "config.yaml").write_text(
+        "tests:\n  - name: yaml-test\n    prompt_file: prompts/yaml.md\n",
+        encoding="utf-8",
+    )
+    (evals_dir / "evals.json").write_text(
+        (
+            "{\n"
+            '  "skill_name": "precedence-skill",\n'
+            '  "evals": [\n'
+            '    {"id": 1, "prompt": "json prompt", "expected_output": "json"}\n'
+            "  ]\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    skill = parse_skill(skill_dir)
+
+    assert skill.evals_config is not None
+    assert len(skill.evals_config.tests) == 1
+    assert skill.evals_config.tests[0].prompt == "json prompt"
+    assert skill.evals_config.tests[0].prompt_file is None
+
+
 def test_parse_invalid_evals_json(tmp_path: Path):
     skill_dir = tmp_path / "bad-evals"
     evals_dir = skill_dir / "evals"


### PR DESCRIPTION
## Summary
- make  the canonical parser input when both eval formats exist
- align README, config docs, and CI/eval guides with shipped behavior and clearly label non-default or placeholder features
- add config and parser tests to lock documented fields and eval precedence

## Verification
- TMPDIR=/Users/vtupe/.openclaw/workspace/projects/skill-gate/repo/.tmp pytest --no-cov -q tests/unit/test_config.py tests/unit/test_parser.py tests/unit/test_quality.py tests/unit/test_agent_runner.py tests/integration/test_agent_runner_integration.py
- Result: 35 passed, 9 warnings

## Issue
- closes #112