### PR TITLE
fix: improve offline remediation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Score: 97/100 | Grade: A | Blockers: 0 | Warnings: 1
 
 > **Note:** `skill-guard validate`, `secure`, `conflict`, `init`, `catalog`, and `check` work fully offline — no agent or API key needed.
 
+The default offline path is already useful on its own: `validate` catches structure and metadata problems, `secure` catches risky patterns with remediation hints, `conflict` flags overlapping triggers, and `check` combines those static gates into one pre-merge decision.
+
 ## Installation
 
 ```bash

--- a/skill_guard/engine/security.py
+++ b/skill_guard/engine/security.py
@@ -237,6 +237,14 @@ def _scan_external_urls(file_path: Path, text: str) -> list[SecurityFinding]:
     findings: list[SecurityFinding] = []
 
     for match in re.finditer(r"https?://[^\s\"')>]+", text):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        line_end = text.find("\n", match.start())
+        if line_end == -1:
+            line_end = len(text)
+        line_text = text[line_start:line_end]
+        if line_text.lstrip().startswith("#"):
+            continue
+
         url = match.group(0)
         parsed = urlparse(url)
         hostname = (parsed.hostname or "").lower()

--- a/skill_guard/engine/similarity.py
+++ b/skill_guard/engine/similarity.py
@@ -95,6 +95,7 @@ def compute_similarity(
             "Merge into a single skill with broader scope",
             "Narrow descriptions to distinguish triggers",
             "Add exclusion hints (e.g., 'Do NOT use for ...')",
+            "Add conflict_ignore in SKILL.md if this overlap is intentional",
         ]
 
         matches.append(
@@ -212,6 +213,7 @@ def _compute_embeddings_similarity(
                     "Merge into a single skill with broader scope",
                     "Narrow descriptions to distinguish triggers",
                     "Add exclusion hints (e.g., 'Do NOT use for ...')",
+                    "Add conflict_ignore in SKILL.md if this overlap is intentional",
                 ],
             )
         )

--- a/skill_guard/output/markdown.py
+++ b/skill_guard/output/markdown.py
@@ -24,7 +24,10 @@ def _validation_md(result: ValidationResult) -> str:
     spec_rows = []
     for check in result.checks:
         status = "✅" if check.passed else ("⚠️" if check.severity == "warning" else "❌")
-        row = f"| {check.check_name} | {status} {check.message} |"
+        detail = f"{status} {check.message}"
+        if not check.passed and check.suggestion:
+            detail += f"<br>→ {check.suggestion}"
+        row = f"| {check.check_name} | {detail} |"
         if check.message.startswith("[anthropic-spec]"):
             spec_rows.append(row)
         else:
@@ -35,7 +38,8 @@ def _validation_md(result: ValidationResult) -> str:
         f"| Check | Result |\n|---|---|\n"
         + "\n".join(base_rows)
         + f"\n\n**Score:** {result.score}/100 (Grade {result.grade}) | "
-        f"Blockers: {result.blockers} | Warnings: {result.warnings}\n"
+        f"Blockers: {result.blockers} | Warnings: {result.warnings} | "
+        f"Status: {_validation_status_label(result)}\n"
     )
     if spec_rows:
         rendered += (
@@ -49,7 +53,8 @@ def _security_md(result: SecurityResult) -> str:
     for f in result.findings:
         status = "✅" if f.suppressed else "❌"
         rows.append(
-            f"| {f.severity} | {status} {f.category} [{f.id}] | {f.file}:{f.line} | {f.description} |"
+            f"| {f.severity} | {status} {f.category} [{f.id}] | {f.file}:{f.line} | "
+            f"{f.description}<br>→ {f.suggestion} |"
         )
 
     if not rows:
@@ -57,22 +62,42 @@ def _security_md(result: SecurityResult) -> str:
 
     return (
         f"## skill-guard secure — `{result.skill_name}`\n\n"
-        f"| Severity | Finding | Location | Description |\n|---|---|---|---|\n" + "\n".join(rows)
+        f"| Severity | Finding | Location | Description |\n|---|---|---|---|\n"
+        + "\n".join(rows)
+        + (
+            f"\n\n**Critical:** {result.critical_count} | **High:** {result.high_count} | "
+            f"**Medium:** {result.medium_count} | **Low:** {result.low_count} | "
+            f"**Status:** {_security_status_label(result)}"
+        )
     )
 
 
 def _conflict_md(result: ConflictResult) -> str:
     rows = []
+    if result.name_collision:
+        rows.append(
+            f"| {result.name_collision_with} | ❌ name collision | 1.0 | "
+            "Rename one skill so the identifiers are clearly distinct. |"
+        )
     for m in result.matches:
         status = "❌" if m.severity == "high" else "⚠️"
-        rows.append(f"| {m.existing_skill_name} | {status} {m.severity} | {m.similarity_score} |")
+        rows.append(
+            f"| {m.existing_skill_name} | {status} {m.severity} | {m.similarity_score} | "
+            f"{', '.join(m.suggestions)} |"
+        )
 
     if not rows:
-        rows.append("| - | ✅ No conflicts | - |")
+        rows.append("| - | ✅ No conflicts | - | - |")
 
     return (
         f"## skill-guard conflict — `{result.skill_name}`\n\n"
-        f"| Skill | Severity | Score |\n|---|---|---|\n" + "\n".join(rows)
+        f"| Skill | Severity | Score | Remediation |\n|---|---|---|---|\n"
+        + "\n".join(rows)
+        + (
+            f"\n\n**High conflicts:** {result.high_conflicts} | "
+            f"**Medium conflicts:** {result.medium_conflicts} | "
+            f"**Status:** {_conflict_status_label(result)}"
+        )
     )
 
 
@@ -103,3 +128,25 @@ def _check_run_md(result: CheckRunReport) -> str:
         "| Skill | Change | Validation | Security | Conflict | Test | Status |\n"
         "|---|---|---|---|---|---|---|\n" + "\n".join(rows)
     )
+
+
+def _validation_status_label(result: ValidationResult) -> str:
+    if result.blockers > 0:
+        return "blocking failures"
+    if result.warnings > 0:
+        return "warnings only (non-blocking by default)"
+    return "clean"
+
+
+def _security_status_label(result: SecurityResult) -> str:
+    if result.passed:
+        return "no blocking findings"
+    return "blocking findings present"
+
+
+def _conflict_status_label(result: ConflictResult) -> str:
+    if result.name_collision or result.high_conflicts > 0:
+        return "blocking conflicts present"
+    if result.medium_conflicts > 0:
+        return "warnings only"
+    return "clean"

--- a/skill_guard/output/text.py
+++ b/skill_guard/output/text.py
@@ -34,7 +34,8 @@ def format_validation_result(
 
     console.print(
         f"Score: {result.score}/100 | Grade: {result.grade} | "
-        f"Blockers: {result.blockers} | Warnings: {result.warnings}"
+        f"Blockers: {result.blockers} | Warnings: {result.warnings} | "
+        f"Status: {_validation_status_label(result)}"
     )
 
 
@@ -63,9 +64,13 @@ def format_security_result(result: SecurityResult, quiet: bool = False) -> None:
     table.add_column("Severity")
     table.add_column("Finding")
 
-    for finding in result.findings:
-        if quiet and finding.suppressed:
-            continue
+    visible_findings = [
+        finding for finding in result.findings if not (quiet and finding.suppressed)
+    ]
+    if not visible_findings:
+        table.add_row("✅ none", "No security findings detected")
+
+    for finding in visible_findings:
         status = "✅" if finding.suppressed else "❌"
         msg = f"{finding.category} [{finding.id}] in {finding.file}:{finding.line}\n{finding.description}\n→ {finding.suggestion}"
         table.add_row(f"{status} {finding.severity}", msg)
@@ -73,7 +78,8 @@ def format_security_result(result: SecurityResult, quiet: bool = False) -> None:
     console.print(table)
     console.print(
         f"Critical: {result.critical_count} | High: {result.high_count} | "
-        f"Medium: {result.medium_count} | Low: {result.low_count}"
+        f"Medium: {result.medium_count} | Low: {result.low_count} | "
+        f"Status: {_security_status_label(result)}"
     )
 
 
@@ -94,7 +100,33 @@ def format_conflict_result(result: ConflictResult, quiet: bool = False) -> None:
         )
         table.add_row(f"{status} {match.existing_skill_name}", details)
 
+    if not result.name_collision and not result.matches:
+        table.add_row("✅ none", "No conflicting skills detected")
+
     console.print(table)
     console.print(
-        f"High conflicts: {result.high_conflicts} | Medium conflicts: {result.medium_conflicts}"
+        f"High conflicts: {result.high_conflicts} | Medium conflicts: {result.medium_conflicts} | "
+        f"Status: {_conflict_status_label(result)}"
     )
+
+
+def _validation_status_label(result: ValidationResult) -> str:
+    if result.blockers > 0:
+        return "blocking failures"
+    if result.warnings > 0:
+        return "warnings only (non-blocking by default)"
+    return "clean"
+
+
+def _security_status_label(result: SecurityResult) -> str:
+    if result.passed:
+        return "no blocking findings"
+    return "blocking findings present"
+
+
+def _conflict_status_label(result: ConflictResult) -> str:
+    if result.name_collision or result.high_conflicts > 0:
+        return "blocking conflicts present"
+    if result.medium_conflicts > 0:
+        return "warnings only"
+    return "clean"

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -5,7 +5,10 @@ from skill_guard.models import (
     CheckResult,
     CheckRunReport,
     CheckSkillReport,
+    ConflictMatch,
     ConflictResult,
+    SecurityFinding,
+    SecurityResult,
     ValidationResult,
 )
 from skill_guard.output.json_out import format_as_json
@@ -119,3 +122,73 @@ def test_markdown_output_supports_aggregate_check_report():
 
     assert "## skill-guard check" in md
     assert "| alpha | modified | passed | passed | passed | skipped | passed |" in md
+
+
+def test_markdown_output_includes_remediation_and_status_summaries():
+    validation = ValidationResult(
+        skill_name="alpha",
+        skill_path=Path("/tmp/alpha"),
+        checks=[
+            CheckResult(
+                check_name="evals_directory_exists",
+                passed=False,
+                severity="warning",
+                message="No evals/ directory found",
+                suggestion="Create evals/evals.json.",
+            )
+        ],
+        score=92,
+        grade="A",
+        passed=True,
+        warnings=1,
+        blockers=0,
+    )
+    security = SecurityResult(
+        skill_name="alpha",
+        findings=[
+            SecurityFinding(
+                id="URL-001",
+                severity="medium",
+                category="DATA_EXFILTRATION",
+                file="scripts/setup.sh",
+                line=2,
+                pattern="https?://",
+                matched_text="https://example.com",
+                description="External URL found in script file",
+                suggestion="Set secure.allow_external_urls_in_scripts: true when intentional.",
+                suppressed=False,
+            )
+        ],
+        passed=True,
+        critical_count=0,
+        high_count=0,
+        medium_count=1,
+        low_count=0,
+    )
+    conflict = ConflictResult(
+        skill_name="alpha",
+        matches=[
+            ConflictMatch(
+                existing_skill_name="beta",
+                similarity_score=0.66,
+                severity="medium",
+                overlapping_phrases=["diagnose latency"],
+                suggestions=["Add conflict_ignore in SKILL.md if this overlap is intentional"],
+            )
+        ],
+        name_collision=False,
+        passed=True,
+        high_conflicts=0,
+        medium_conflicts=1,
+    )
+
+    validation_md = format_as_markdown(validation, command="validate")
+    security_md = format_as_markdown(security, command="secure")
+    conflict_md = format_as_markdown(conflict, command="conflict")
+
+    assert "→ Create evals/evals.json." in validation_md
+    assert "Status: warnings only (non-blocking by default)" in validation_md
+    assert "secure.allow_external_urls_in_scripts: true when intentional" in security_md
+    assert "Status:** no blocking findings" in security_md
+    assert "Add conflict_ignore in SKILL.md if this overlap is intentional" in conflict_md
+    assert "Status:** warnings only" in conflict_md

--- a/tests/unit/test_output_text.py
+++ b/tests/unit/test_output_text.py
@@ -69,3 +69,58 @@ def test_text_formatters_smoke():
     format_validation_result(val, quiet=True)
     format_security_result(sec, quiet=True)
     format_conflict_result(conflict)
+
+
+def test_text_formatters_include_status_labels(capsys) -> None:
+    val = ValidationResult(
+        skill_name="x",
+        skill_path=Path("/tmp/x"),
+        checks=[
+            CheckResult(
+                check_name="c",
+                passed=False,
+                severity="warning",
+                message="warning",
+                suggestion="fix it",
+            )
+        ],
+        score=95,
+        grade="A",
+        passed=True,
+        warnings=1,
+        blockers=0,
+    )
+    sec = SecurityResult(
+        skill_name="x",
+        findings=[],
+        passed=True,
+        critical_count=0,
+        high_count=0,
+        medium_count=0,
+        low_count=0,
+    )
+    conflict = ConflictResult(
+        skill_name="x",
+        matches=[
+            ConflictMatch(
+                existing_skill_name="y",
+                similarity_score=0.61,
+                severity="medium",
+                overlapping_phrases=["foo"],
+                suggestions=["Add conflict_ignore in SKILL.md if this overlap is intentional"],
+            )
+        ],
+        name_collision=False,
+        passed=True,
+        high_conflicts=0,
+        medium_conflicts=1,
+    )
+
+    format_validation_result(val)
+    format_security_result(sec)
+    format_conflict_result(conflict)
+
+    output = capsys.readouterr().out
+    assert "non-blocking by default" in output
+    assert "Status: no blocking findings" in output
+    assert "Status: warnings only" in output

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -47,3 +47,27 @@ def test_security_skip_references_suppresses_reference_findings() -> None:
     injection_ids = {finding.id for finding in result.findings if finding.category == "INJECTION"}
     assert "INJECT-003" not in injection_ids
     assert "INJECT-001" in injection_ids
+
+
+def test_security_ignores_external_urls_in_comment_only_script(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "comment-url-skill"
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        (
+            "---\n"
+            "name: comment-url-skill\n"
+            'description: "Use when checking whether comment-only URLs trigger false positives."\n'
+            "---\n"
+        ),
+        encoding="utf-8",
+    )
+    (scripts_dir / "setup.sh").write_text(
+        "# docs: https://example.com/install\necho ready\n",
+        encoding="utf-8",
+    )
+
+    skill = parse_skill(skill_dir)
+    result = run_security_scan(skill, SecureConfig())
+
+    assert all(f.id != "URL-001" for f in result.findings)


### PR DESCRIPTION
## Summary
- reduce one noisy static false positive by ignoring comment-only external URLs in scripts
- include remediation guidance in markdown output for validate, secure, and conflict
- make text and markdown summaries explicitly state blocking vs warning-only vs clean

## Verification
- TMPDIR=$PWD/.tmp pytest --no-cov -q tests/unit/test_security.py tests/unit/test_output.py tests/unit/test_output_text.py tests/unit/test_similarity.py
- Result: 21 passed

## Issue
- closes #113