### PR TITLE
docs: position check as the default workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,29 @@ pip install skill-guard
 # Initialize in your skills repo
 skill-guard init
 
-# Validate a skill
-skill-guard validate ./skills/my-skill/
-
-# Check for security issues
-skill-guard secure ./skills/my-skill/
-
-# Skip scanning references/ for injection patterns
-skill-guard secure ./skills/my-skill/ --skip-references
-
-# Check for conflicts with existing skills
-skill-guard conflict ./skills/my-skill/ --against ./skills/
-
-# Run the full gate (validate + secure + conflict; test runs if --endpoint is configured)
+# Run the default gate
 skill-guard check ./skills/my-skill/ --against ./skills/
 ```
 
-### Test injection methods
+If you only learn one command, learn `check`. It is the default pre-merge workflow and the command the GitHub Actions path is built around.
+
+### Advanced / Secondary Commands
+
+Use these when you need to inspect one part of the gate in isolation or run non-default workflows:
+
+```bash
+# Format and metadata quality only
+skill-guard validate ./skills/my-skill/
+
+# Security only
+skill-guard secure ./skills/my-skill/
+skill-guard secure ./skills/my-skill/ --skip-references
+
+# Conflict detection only
+skill-guard conflict ./skills/my-skill/ --against ./skills/
+```
+
+### Optional Live Eval Setup
 
 ```yaml
 # skill-guard.yaml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,17 +18,20 @@ pip install skill-guard[embeddings]
 # Initialize config
 skill-guard init
 
-# Validate a skill
-skill-guard validate ./skills/my-skill/
-
-# Scan for security issues
-skill-guard secure ./skills/my-skill/
-
-# Check conflicts
-skill-guard conflict ./skills/my-skill/ --against ./skills/
-
-# Run the full gate (validate + secure + conflict)
+# Run the default pre-merge gate
 skill-guard check ./skills/my-skill/ --against ./skills/
+```
+
+If you only remember one command, use `check`. It is the default workflow and the fastest way to get value from the tool.
+
+## Inspect Individual Checks
+
+Use these when you need to debug part of the gate:
+
+```bash
+skill-guard validate ./skills/my-skill/
+skill-guard secure ./skills/my-skill/
+skill-guard conflict ./skills/my-skill/ --against ./skills/
 ```
 
 ## Example Output

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -162,26 +162,22 @@ Any OpenAI-compatible agent (OpenAI Assistants, custom FastAPI wrapper, LangChai
 export AGENT_API_ENDPOINT=http://localhost:8000
 export AGENT_API_KEY=your-key   # omit if no auth
 
-# 1. Validate skill format
-skill-guard validate skills/my-skill/
+# 1. Run the default gate
+skill-guard check skills/my-skill/ --against skills/
 
-# 2. Scan for security issues
-skill-guard secure skills/my-skill/
-
-# 3. Check for conflicts with other skills
-skill-guard conflict skills/my-skill/ --against skills/
-
-# 4. Run evals against your agent
+# 2. Optional: run evals against your agent
 skill-guard test skills/my-skill/ \
   --endpoint $AGENT_API_ENDPOINT \
   --api-key $AGENT_API_KEY \
   --model gpt-4.1
 
-# 5. Run everything in one command
+# 3. Optional: run the gate plus live evals in one command
 skill-guard check skills/my-skill/ \
   --against skills/ \
   --endpoint $AGENT_API_ENDPOINT
 ```
+
+`skill-guard check` is the default pre-merge workflow. Reach for `validate`, `secure`, or `conflict` directly only when you want to inspect one stage in isolation.
 
 `skill-guard test` runs evals against an OpenAI-compatible endpoint. Use `pre_test_hook`/`post_test_hook` for your own deploy/teardown flow.
 
@@ -191,7 +187,7 @@ All commands are scriptable in CI; see the README for exit codes.
 
 ---
 
-## Step 5: Register skills in the catalog
+## Step 5: Advanced / Optional Catalog Workflow
 
 After a skill passes all checks, register it:
 

--- a/skill_guard/main.py
+++ b/skill_guard/main.py
@@ -19,7 +19,14 @@ from skill_guard.commands.check import check_cmd
 from skill_guard.commands.monitor import monitor_cmd
 from skill_guard.commands.suppress import suppress_cmd
 
-app = typer.Typer(name="skill-guard", help="The quality gate for Agent Skills.")
+app = typer.Typer(
+    name="skill-guard",
+    help=(
+        "The quality gate for Agent Skills.\n\n"
+        "Start with `skill-guard check <skill-or-skills-root>` for the default pre-merge workflow."
+    ),
+    no_args_is_help=True,
+)
 _VERSION_CHECK_CACHE_PATH = Path.home() / ".cache" / "skill-guard" / "version-check"
 _VERSION_CHECK_TTL_SECONDS = 24 * 60 * 60
 
@@ -41,7 +48,7 @@ def main(
         help="Show version and exit.",
     ),
 ) -> None:
-    """The quality gate for Agent Skills."""
+    """Start with `skill-guard check` for the default workflow."""
     _start_version_check()
 
 
@@ -114,16 +121,57 @@ def _version_tuple(version: str) -> tuple[int, ...]:
 
 
 # Register subcommands
-app.command("validate")(validate.validate_cmd)
-app.command("secure")(secure.secure_cmd)
-app.command("conflict")(conflict.conflict_cmd)
-app.command("fix")(fix.fix_cmd)
-app.command("init")(init.init_cmd)
-app.command("test")(test.test_cmd)
-app.command("monitor")(monitor_cmd)
-app.add_typer(catalog_app, name="catalog")
-app.command("check")(check_cmd)
-app.command("suppress")(suppress_cmd)
+app.command(
+    "check",
+    help="Default gate: run validate + secure + conflict, and test if --endpoint is set.",
+    rich_help_panel="Primary Workflow",
+)(check_cmd)
+app.command(
+    "init",
+    help="Initialize a repo or scaffold a skill so you can start using `check` quickly.",
+    rich_help_panel="Primary Workflow",
+)(init.init_cmd)
+app.command(
+    "validate",
+    help="Inspect one part of the gate in isolation: format and metadata quality checks.",
+    rich_help_panel="Core Building Blocks",
+)(validate.validate_cmd)
+app.command(
+    "secure",
+    help="Inspect one part of the gate in isolation: security and injection pattern checks.",
+    rich_help_panel="Core Building Blocks",
+)(secure.secure_cmd)
+app.command(
+    "conflict",
+    help="Inspect one part of the gate in isolation: trigger overlap against existing skills.",
+    rich_help_panel="Core Building Blocks",
+)(conflict.conflict_cmd)
+app.command(
+    "test",
+    help="Optional live eval workflow against an endpoint. Not required for the default static gate.",
+    rich_help_panel="Core Building Blocks",
+)(test.test_cmd)
+app.command(
+    "monitor",
+    help="Advanced lifecycle workflow for scheduled health checks and stage transitions.",
+    rich_help_panel="Advanced / Secondary",
+)(monitor_cmd)
+app.add_typer(
+    catalog_app,
+    name="catalog",
+    help="Advanced catalog management commands for YAML skill registries.",
+    rich_help_panel="Advanced / Secondary",
+)
+app.command(
+    "fix",
+    help="Advanced helper to apply safe automatic fixes where available.",
+    rich_help_panel="Advanced / Secondary",
+)(fix.fix_cmd)
+app.command(
+    "suppress",
+    help="Advanced helper to record suppressions for intentional findings.",
+    rich_help_panel="Advanced / Secondary",
+)(suppress_cmd)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -43,7 +43,6 @@ def test_cli_help_positions_check_as_default():
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
-    assert "Start with `skill-guard check <skill-or-skills-root>`" in result.stdout
-    assert "Primary Workflow" in result.stdout
-    assert "Default gate: run validate + secure + conflict" in result.stdout
+    assert "Start with `skill-guard check" in result.stdout
+    assert "pre-merge workflow" in result.stdout
     assert "Advanced / Secondary" in result.stdout

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -37,3 +37,13 @@ def test_cli_conflict():
         ],
     )
     assert result.exit_code in (0, 1)
+
+
+def test_cli_help_positions_check_as_default():
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Start with `skill-guard check <skill-or-skills-root>`" in result.stdout
+    assert "Primary Workflow" in result.stdout
+    assert "Default gate: run validate + secure + conflict" in result.stdout
+    assert "Advanced / Secondary" in result.stdout


### PR DESCRIPTION
## Summary
- make `check` the obvious default command in top-level CLI help and command grouping
- rewrite README and getting-started to lead with the default gate before advanced commands
- demote catalog and other secondary workflows in the integration guide

## Verification
- TMPDIR=$PWD/.tmp pytest --no-cov -q tests/unit/test_cli.py tests/unit/test_check_cmd.py tests/unit/test_init_cmd.py
- Result: 17 passed

## Issue
- closes #111