### PR TITLE
test: harden deterministic CI eval workflow

### DIFF
--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -108,6 +108,13 @@ Warnings remain in the markdown and JSON reports, but the canonical PR gate stay
 
 For the full eval iteration loop (run → review → revise → expand tests), see [Writing Evals](eval-authoring-guide.md). If you want persistent artifacts for manual review, use `--workspace` as described in [Workspace output](eval-authoring-guide.md#workspace-output-agentskills-eval-artifacts).
 
+Recommended CI path:
+- use `test.injection.method: custom_hook`
+- use a stable `reload_health_check_path`
+- use `--workspace` so every run writes deterministic debug artifacts
+
+`directory_copy` and `git_push` remain supported, but they are secondary paths. They add host or repo state that is harder to keep deterministic in CI.
+
 ### Prerequisites
 
 1. Your skill must have an `evals/` directory with either `config.yaml` (prompt files) or `evals.json` (inline prompts):
@@ -168,6 +175,7 @@ skill-guard test skills/my-skill \
   --endpoint https://your-agent.example.com \
   --api-key $AGENT_API_KEY \
   --model gpt-4.1 \
+  --workspace ./eval-workspace \
   --format json
 ```
 
@@ -249,6 +257,8 @@ test:
 ```
 
 Hook scripts receive two arguments: `<skill_path> <endpoint_url>`. Exit non-zero to abort the test run.
+
+This is the recommended CI injection path. Keep the hook idempotent, pair it with a health endpoint, and rely on workspace artifacts for failed-run diagnosis.
 
 ---
 

--- a/docs/eval-authoring-guide.md
+++ b/docs/eval-authoring-guide.md
@@ -173,13 +173,20 @@ skill-guard test ./skills/my-skill/ \
 Baseline runs execute the same evals without injecting the skill (no hooks or copy),
 then compare pass/fail outcomes and aggregate deltas.
 
+For CI, prefer a single deterministic path:
+- `test.injection.method: custom_hook`
+- a stable health endpoint
+- `--workspace` enabled
+
+Treat `directory_copy` and `git_push` as secondary workflows for specialized setups, not the default CI path.
+
 ---
 
 ## Workspace output (AgentSkills eval artifacts)
 
 Use `--workspace` to write eval artifacts to disk in the AgentSkills-compatible
-layout. Each run creates a new `iteration-N` directory with per-test outputs and
-an aggregated `benchmark.json`.
+layout. Each run creates a new `iteration-N` directory with per-test outputs, a
+stable `run.json` describing the setup, and an aggregated `benchmark.json`.
 
 ```bash
 skill-guard test ./skills/my-skill/ \
@@ -193,6 +200,7 @@ Directory layout:
 ```
 ./eval-workspace/
   iteration-1/
+    run.json
     with_skill/
       <test-name>/
         outputs/
@@ -205,6 +213,8 @@ Directory layout:
 
 When `--baseline` is enabled, the iteration includes both `with_skill/` and
 `without_skill/` directories, and `benchmark.json` captures the deltas.
+If setup fails before eval execution starts, the iteration still includes
+`run.json` plus `setup_failure.json` with the error type, message, and remediation steps.
 
 ---
 

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -114,6 +114,8 @@ echo "Restarted $CONTAINER with $(basename "$SKILL_PATH")"
 
 After the pre-test hook runs, skill-guard can optionally execute `test.reload_command`, wait `reload_wait_seconds`, then poll `GET {endpoint}{reload_health_check_path}` until it returns 200 or `reload_timeout_seconds` is exceeded. The default health path is `/health`.
 
+For CI, this hook-based path is the recommended injection strategy. Keep the hook idempotent, expose a deterministic health endpoint, and run with `--workspace` so failed setup runs emit `setup_failure.json` and `run.json` for debugging.
+
 ```python
 # FastAPI example
 @app.get("/health")

--- a/skill_guard/commands/test.py
+++ b/skill_guard/commands/test.py
@@ -9,9 +9,14 @@ from typing import Any
 import typer
 
 from skill_guard.config import ConfigError, TestConfig, load_config
-from skill_guard.engine.agent_runner import run_agent_tests, run_agent_tests_with_baseline
+from skill_guard.engine.agent_runner import (
+    build_test_remediation,
+    run_agent_tests,
+    run_agent_tests_with_baseline,
+)
 from skill_guard.models import HealthCheckTimeoutError, HookError, SkillParseError
 from skill_guard.output.json_out import format_as_json
+from skill_guard.output.workspace import write_workspace_setup_failure
 from skill_guard.parser import parse_skill
 
 SKILL_PATH_ARG = typer.Argument(..., help="Path to skill directory")
@@ -139,6 +144,7 @@ def test_cmd(
     )
 
     run_baseline = baseline or getattr(config.test, "baseline", False)
+    test_mode = "baseline_comparison" if run_baseline else "with_skill"
 
     try:
         if run_baseline:
@@ -146,10 +152,22 @@ def test_cmd(
         else:
             result = asyncio.run(run_agent_tests(skill, merged_test_config))
     except HealthCheckTimeoutError as e:
-        typer.echo(f"Test setup error: {e}")
+        _write_setup_failure_artifact(
+            skill_name=skill.metadata.name,
+            test_mode=test_mode,
+            test_config=merged_test_config,
+            error=e,
+        )
+        typer.echo(_format_setup_error("Health check failed", e, merged_test_config))
         raise typer.Exit(code=6) from e
     except HookError as e:
-        typer.echo(f"Test setup error: {e}")
+        _write_setup_failure_artifact(
+            skill_name=skill.metadata.name,
+            test_mode=test_mode,
+            test_config=merged_test_config,
+            error=e,
+        )
+        typer.echo(_format_setup_error("Injection/setup failed", e, merged_test_config))
         raise typer.Exit(code=5) from e
     except OSError as e:
         typer.echo(f"Test execution error: {e}")
@@ -170,3 +188,49 @@ def test_cmd(
     else:
         if result.pass_rate < 1.0:
             raise typer.Exit(code=1)
+
+
+def _write_setup_failure_artifact(
+    *,
+    skill_name: str,
+    test_mode: str,
+    test_config: TestConfig,
+    error: Exception,
+) -> None:
+    if not test_config.workspace_dir:
+        return
+
+    write_workspace_setup_failure(
+        Path(test_config.workspace_dir),
+        skill_name=skill_name,
+        endpoint=test_config.endpoint,
+        mode=test_mode,
+        injection_method=test_config.injection.method,
+        model=test_config.model,
+        timeout_seconds=test_config.timeout_seconds,
+        reload_command=test_config.reload_command,
+        reload_wait_seconds=test_config.reload_wait_seconds,
+        reload_health_check_path=test_config.reload_health_check_path,
+        reload_timeout_seconds=test_config.reload_timeout_seconds,
+        stage="setup",
+        error_type=type(error).__name__,
+        error_message=str(error),
+        remediation=build_test_remediation(test_config, error),
+    )
+
+
+def _format_setup_error(prefix: str, error: Exception, test_config: TestConfig) -> str:
+    remediation = build_test_remediation(test_config, error)
+    lines = [
+        f"Test setup error: {prefix}: {error}",
+        f"  injection_method={test_config.injection.method}",
+    ]
+    if test_config.reload_command:
+        lines.append(f"  reload_command={test_config.reload_command}")
+    lines.extend(f"  remediation: {step}" for step in remediation)
+    if test_config.workspace_dir:
+        lines.append(
+            f"  workspace_artifact={Path(test_config.workspace_dir)} "
+            "(see latest iteration setup_failure.json)"
+        )
+    return "\n".join(lines)

--- a/skill_guard/engine/agent_runner.py
+++ b/skill_guard/engine/agent_runner.py
@@ -62,7 +62,7 @@ def build_test_remediation(config: TestConfig, error: Exception) -> list[str]:
 
     injection_method = config.injection.method
     remediation = [
-        f"Recommended CI path: use test.injection.method: custom_hook for deterministic setup.",
+        "Recommended CI path: use test.injection.method: custom_hook for deterministic setup.",
     ]
     if injection_method == "custom_hook":
         remediation.extend(

--- a/skill_guard/engine/agent_runner.py
+++ b/skill_guard/engine/agent_runner.py
@@ -44,6 +44,50 @@ def run_hook(hook_script: Path, skill_path: Path, endpoint: str) -> None:
         raise HookError(f"Hook failed ({hook_script}) with exit code {proc.returncode}: {details}")
 
 
+def build_test_remediation(config: TestConfig, error: Exception) -> list[str]:
+    """Return actionable next steps for setup/test failures."""
+    if isinstance(error, HealthCheckTimeoutError):
+        return [
+            f"Verify the agent is reachable at {config.endpoint or '<missing endpoint>'}.",
+            (
+                "Confirm the health endpoint responds with HTTP 200 at "
+                f"{config.reload_health_check_path} after injection or reload."
+            ),
+            (
+                "Increase test.reload_timeout_seconds if the agent needs longer to reload after "
+                "skill injection."
+            ),
+            "If you use hooks, check the pre-test hook and reload_command output first.",
+        ]
+
+    injection_method = config.injection.method
+    remediation = [
+        f"Recommended CI path: use test.injection.method: custom_hook for deterministic setup.",
+    ]
+    if injection_method == "custom_hook":
+        remediation.extend(
+            [
+                "Verify the pre_test_hook and post_test_hook paths exist and are executable.",
+                "Run the hook scripts manually against the same skill path and endpoint to confirm they succeed.",
+            ]
+        )
+    elif injection_method == "directory_copy":
+        remediation.extend(
+            [
+                "Prefer custom_hook in CI. directory_copy is better suited to local or single-host setups.",
+                "Verify test.injection.directory_copy_dir exists and the agent reloads from that directory deterministically.",
+            ]
+        )
+    elif injection_method == "git_push":
+        remediation.extend(
+            [
+                "Prefer custom_hook in CI. git_push adds repo and network state that is harder to make deterministic.",
+                "Verify git_repo_path, git_remote, and the target branch are writable from the CI runner.",
+            ]
+        )
+    return remediation
+
+
 async def wait_for_agent_ready(
     endpoint: str,
     api_key: str | None,
@@ -184,7 +228,17 @@ async def run_agent_tests(
     )
 
     if config.workspace_dir and write_workspace:
-        write_workspace_results(result, Path(config.workspace_dir))
+        write_workspace_results(
+            result,
+            Path(config.workspace_dir),
+            injection_method=config.injection.method,
+            model=config.model,
+            timeout_seconds=config.timeout_seconds,
+            reload_command=config.reload_command,
+            reload_wait_seconds=config.reload_wait_seconds,
+            reload_health_check_path=config.reload_health_check_path,
+            reload_timeout_seconds=config.reload_timeout_seconds,
+        )
 
     return result
 
@@ -242,7 +296,17 @@ async def run_agent_tests_with_baseline(
     )
 
     if config.workspace_dir:
-        write_workspace_comparison(result, Path(config.workspace_dir))
+        write_workspace_comparison(
+            result,
+            Path(config.workspace_dir),
+            injection_method=config.injection.method,
+            model=config.model,
+            timeout_seconds=config.timeout_seconds,
+            reload_command=config.reload_command,
+            reload_wait_seconds=config.reload_wait_seconds,
+            reload_health_check_path=config.reload_health_check_path,
+            reload_timeout_seconds=config.reload_timeout_seconds,
+        )
 
     return result
 

--- a/skill_guard/output/workspace.py
+++ b/skill_guard/output/workspace.py
@@ -83,14 +83,77 @@ def _benchmark_payload(result: AgentTestResult) -> dict[str, Any]:
     }
 
 
-def write_workspace_results(result: AgentTestResult, workspace_root: Path) -> Path:
+def _run_metadata_payload(
+    result: AgentTestResult,
+    *,
+    mode: str,
+    injection_method: str,
+    model: str | None,
+    timeout_seconds: int,
+    reload_command: str | None,
+    reload_wait_seconds: int,
+    reload_health_check_path: str,
+    reload_timeout_seconds: int,
+) -> dict[str, Any]:
+    return {
+        "skill_name": result.skill_name,
+        "endpoint": result.endpoint,
+        "mode": mode,
+        "injection_method": injection_method,
+        "model": model,
+        "timeout_seconds": timeout_seconds,
+        "reload_command": reload_command,
+        "reload_wait_seconds": reload_wait_seconds,
+        "reload_health_check_path": reload_health_check_path,
+        "reload_timeout_seconds": reload_timeout_seconds,
+        "tests": [test.test_name for test in result.results],
+    }
+
+
+def write_workspace_results(
+    result: AgentTestResult,
+    workspace_root: Path,
+    *,
+    injection_method: str,
+    model: str | None,
+    timeout_seconds: int,
+    reload_command: str | None,
+    reload_wait_seconds: int,
+    reload_health_check_path: str,
+    reload_timeout_seconds: int,
+) -> Path:
     iteration_dir = _next_iteration_dir(workspace_root)
     _write_run(iteration_dir, "with_skill", result)
     _write_json(iteration_dir / "benchmark.json", _benchmark_payload(result))
+    _write_json(
+        iteration_dir / "run.json",
+        _run_metadata_payload(
+            result,
+            mode="with_skill",
+            injection_method=injection_method,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            reload_command=reload_command,
+            reload_wait_seconds=reload_wait_seconds,
+            reload_health_check_path=reload_health_check_path,
+            reload_timeout_seconds=reload_timeout_seconds,
+        ),
+    )
     return iteration_dir
 
 
-def write_workspace_comparison(result: AgentTestComparisonResult, workspace_root: Path) -> Path:
+def write_workspace_comparison(
+    result: AgentTestComparisonResult,
+    workspace_root: Path,
+    *,
+    injection_method: str,
+    model: str | None,
+    timeout_seconds: int,
+    reload_command: str | None,
+    reload_wait_seconds: int,
+    reload_health_check_path: str,
+    reload_timeout_seconds: int,
+) -> Path:
     iteration_dir = _next_iteration_dir(workspace_root)
     _write_run(iteration_dir, "with_skill", result.with_skill)
     _write_run(iteration_dir, "without_skill", result.baseline)
@@ -107,6 +170,69 @@ def write_workspace_comparison(result: AgentTestComparisonResult, workspace_root
             "regressed_tests": result.regressed_tests,
             "unchanged_tests": result.unchanged_tests,
             "passed": result.passed,
+        },
+    )
+    _write_json(
+        iteration_dir / "run.json",
+        {
+            "skill_name": result.skill_name,
+            "endpoint": result.endpoint,
+            "mode": "baseline_comparison",
+            "injection_method": injection_method,
+            "model": model,
+            "timeout_seconds": timeout_seconds,
+            "reload_command": reload_command,
+            "reload_wait_seconds": reload_wait_seconds,
+            "reload_health_check_path": reload_health_check_path,
+            "reload_timeout_seconds": reload_timeout_seconds,
+            "tests": [test.test_name for test in result.with_skill.results],
+        },
+    )
+    return iteration_dir
+
+
+def write_workspace_setup_failure(
+    workspace_root: Path,
+    *,
+    skill_name: str,
+    endpoint: str | None,
+    mode: str,
+    injection_method: str,
+    model: str | None,
+    timeout_seconds: int,
+    reload_command: str | None,
+    reload_wait_seconds: int,
+    reload_health_check_path: str,
+    reload_timeout_seconds: int,
+    stage: str,
+    error_type: str,
+    error_message: str,
+    remediation: list[str],
+) -> Path:
+    iteration_dir = _next_iteration_dir(workspace_root)
+    _write_json(
+        iteration_dir / "run.json",
+        {
+            "skill_name": skill_name,
+            "endpoint": endpoint,
+            "mode": mode,
+            "injection_method": injection_method,
+            "model": model,
+            "timeout_seconds": timeout_seconds,
+            "reload_command": reload_command,
+            "reload_wait_seconds": reload_wait_seconds,
+            "reload_health_check_path": reload_health_check_path,
+            "reload_timeout_seconds": reload_timeout_seconds,
+            "tests": [],
+        },
+    )
+    _write_json(
+        iteration_dir / "setup_failure.json",
+        {
+            "stage": stage,
+            "error_type": error_type,
+            "error_message": error_message,
+            "remediation": remediation,
         },
     )
     return iteration_dir

--- a/tests/unit/test_test_cmd.py
+++ b/tests/unit/test_test_cmd.py
@@ -257,6 +257,8 @@ def test_test_cmd_exits_five_on_hook_error(monkeypatch) -> None:
     )
     assert result.exit_code == 5
     assert "Test setup error" in result.stdout
+    assert "injection_method=custom_hook" in result.stdout
+    assert "Recommended CI path" in result.stdout
 
 
 def test_test_cmd_exits_six_on_health_check_timeout(monkeypatch) -> None:
@@ -277,3 +279,30 @@ def test_test_cmd_exits_six_on_health_check_timeout(monkeypatch) -> None:
     )
     assert result.exit_code == 6
     assert "Test setup error" in result.stdout
+    assert "Health check failed" in result.stdout
+    assert "reload_timeout_seconds" in result.stdout
+
+
+def test_test_cmd_writes_workspace_artifact_on_setup_error(tmp_path: Path, monkeypatch) -> None:
+    async def fake_run_agent_tests(skill, config):  # noqa: ARG001
+        raise HookError("pre-test hook failed")
+
+    monkeypatch.setattr("skill_guard.commands.test.run_agent_tests", fake_run_agent_tests)
+    result = runner.invoke(
+        app,
+        [
+            "test",
+            str(FIXTURES / "valid-skill"),
+            "--endpoint",
+            "https://mock-agent.test",
+            "--model",
+            "gpt-4.1",
+            "--workspace",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 5
+    iteration_dir = tmp_path / "iteration-1"
+    assert (iteration_dir / "setup_failure.json").is_file()
+    assert (iteration_dir / "run.json").is_file()

--- a/tests/unit/test_workspace_output.py
+++ b/tests/unit/test_workspace_output.py
@@ -9,7 +9,11 @@ from skill_guard.models import (
     EvalTestComparison,
     EvalTestResult,
 )
-from skill_guard.output.workspace import write_workspace_comparison, write_workspace_results
+from skill_guard.output.workspace import (
+    write_workspace_comparison,
+    write_workspace_results,
+    write_workspace_setup_failure,
+)
 
 
 def _result(name: str, passed: bool) -> AgentTestResult:
@@ -40,7 +44,17 @@ def _result(name: str, passed: bool) -> AgentTestResult:
 
 
 def test_write_workspace_results(tmp_path: Path) -> None:
-    iteration_dir = write_workspace_results(_result("basic test", True), tmp_path)
+    iteration_dir = write_workspace_results(
+        _result("basic test", True),
+        tmp_path,
+        injection_method="custom_hook",
+        model="gpt-4.1",
+        timeout_seconds=30,
+        reload_command="./reload-agent.sh",
+        reload_wait_seconds=5,
+        reload_health_check_path="/health",
+        reload_timeout_seconds=60,
+    )
     outputs_dir = iteration_dir / "with_skill" / "basic_test" / "outputs"
 
     assert outputs_dir.is_dir()
@@ -51,6 +65,10 @@ def test_write_workspace_results(tmp_path: Path) -> None:
     grading = json.loads((outputs_dir / "grading.json").read_text(encoding="utf-8"))
     assert grading["passed"] is True
     assert (iteration_dir / "benchmark.json").is_file()
+    run = json.loads((iteration_dir / "run.json").read_text(encoding="utf-8"))
+    assert run["injection_method"] == "custom_hook"
+    assert run["reload_command"] == "./reload-agent.sh"
+    assert run["tests"] == ["basic test"]
 
 
 def test_write_workspace_comparison(tmp_path: Path) -> None:
@@ -79,8 +97,46 @@ def test_write_workspace_comparison(tmp_path: Path) -> None:
         passed=True,
     )
 
-    iteration_dir = write_workspace_comparison(comparison, tmp_path)
+    iteration_dir = write_workspace_comparison(
+        comparison,
+        tmp_path,
+        injection_method="custom_hook",
+        model="gpt-4.1",
+        timeout_seconds=30,
+        reload_command=None,
+        reload_wait_seconds=0,
+        reload_health_check_path="/health",
+        reload_timeout_seconds=60,
+    )
 
     assert (iteration_dir / "with_skill" / "basic" / "outputs" / "response.txt").is_file()
     assert (iteration_dir / "without_skill" / "basic" / "outputs" / "response.txt").is_file()
     assert (iteration_dir / "benchmark.json").is_file()
+    run = json.loads((iteration_dir / "run.json").read_text(encoding="utf-8"))
+    assert run["mode"] == "baseline_comparison"
+    assert run["tests"] == ["basic"]
+
+
+def test_write_workspace_setup_failure(tmp_path: Path) -> None:
+    iteration_dir = write_workspace_setup_failure(
+        tmp_path,
+        skill_name="valid-skill",
+        endpoint="https://mock-agent.test",
+        mode="with_skill",
+        injection_method="custom_hook",
+        model="gpt-4.1",
+        timeout_seconds=30,
+        reload_command="./reload-agent.sh",
+        reload_wait_seconds=5,
+        reload_health_check_path="/health",
+        reload_timeout_seconds=60,
+        stage="setup",
+        error_type="HookError",
+        error_message="hook failed",
+        remediation=["Verify the hook path."],
+    )
+
+    setup_failure = json.loads((iteration_dir / "setup_failure.json").read_text(encoding="utf-8"))
+    assert setup_failure["stage"] == "setup"
+    assert setup_failure["error_type"] == "HookError"
+    assert setup_failure["remediation"] == ["Verify the hook path."]


### PR DESCRIPTION
## Summary
- standardize eval workspace output with stable run metadata and setup-failure artifacts
- make test setup and health-check failures emit explicit remediation guidance
- document custom_hook as the recommended deterministic CI injection path

## Testing
- TMPDIR=$PWD/.tmp pytest --no-cov -q tests/unit/test_test_cmd.py tests/unit/test_workspace_output.py tests/unit/test_agent_runner.py tests/integration/test_agent_runner_integration.py

Closes #114