### PR TITLE
feat: unify trust-state output semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ conflict_ignore:
 - `5`: hook script failure
 - `6`: health check timeout
 
+## Trust States
+
+Command output now uses one shared trust-state vocabulary alongside CI-oriented status fields:
+
+- `clean`: no action required
+- `warning`: non-blocking issue; review or tighten before merge if needed
+- `exception`: intentional exception or suppression is present; reviewable, not silent
+- `needs_review`: no blocking failure, but a human still needs to inspect the result
+- `blocking`: the command found a merge-stopping problem
+
 ## Pre-commit
 
 Use `pre-commit` to enforce checks before skill changes land:

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -236,6 +236,17 @@ The JSON contract is:
 - top-level `command` and `timestamp`
 - aggregate `result` payload with run counts, final status, summary, and full per-skill detail
 
+The trust-state contract is:
+- `clean`: no action required
+- `warning`: non-blocking issue
+- `exception`: intentional exception or suppression is present
+- `needs_review`: human review required even though no blocking failure occurred
+- `blocking`: merge-stopping problem
+
+For `check`, keep distinguishing CI-facing `status` from semantic `trust_state`:
+- `status` drives pass/warning/fail behavior in CI
+- `trust_state` explains what kind of attention the finding needs
+
 If you want PR comments, post `skill-guard-summary.md` from the canonical workflow as-is.
 The primary path should not depend on shell glue like `git diff | head -1`; let `check --changed`
 resolve the skill set directly from the PR commit range.

--- a/skill_guard/commands/check.py
+++ b/skill_guard/commands/check.py
@@ -25,6 +25,11 @@ from skill_guard.models import (
 )
 from skill_guard.output.json_out import format_as_json
 from skill_guard.output.markdown import format_as_markdown
+from skill_guard.output.semantics import (
+    check_run_trust_state,
+    check_skill_trust_state,
+    trust_state_label,
+)
 from skill_guard.parser import parse_skill
 
 TARGET_PATH_ARG = typer.Argument(
@@ -57,6 +62,7 @@ def _emit_single(payload: dict[str, Any], output_format: str) -> None:
             f"- conflict: {payload['conflict']}\n"
             f"- test: {payload['test']}\n"
             f"- status: {payload['status']}\n"
+            f"- trust_state: {payload['trust_state']}\n"
             f"- summary: {payload['summary']}\n"
         )
         return
@@ -64,7 +70,8 @@ def _emit_single(payload: dict[str, Any], output_format: str) -> None:
     typer.echo(
         f"skill={payload['skill_name']} validation={payload['validation']} "
         f"security={payload['security']} conflict={payload['conflict']} "
-        f"test={payload['test']} status={payload['status']}\n{payload['summary']}"
+        f"test={payload['test']} status={payload['status']} "
+        f"trust_state={payload['trust_state']}\n{payload['summary']}"
     )
 
 
@@ -81,14 +88,16 @@ def _emit_run(report: CheckRunReport, output_format: str) -> None:
 def _format_text(report: CheckRunReport) -> str:
     lines = [
         f"mode={report.mode} status={report.status} total={report.total_skills} "
-        f"checked={report.checked_skills} skipped={report.skipped_skills}",
+        f"checked={report.checked_skills} skipped={report.skipped_skills} "
+        f"trust_state={trust_state_label(check_run_trust_state(report))}",
         report.summary,
     ]
     for skill in report.skills:
         lines.append(
             f"- {skill.skill_name} [{skill.target_status}] "
             f"validation={skill.validation} security={skill.security} "
-            f"conflict={skill.conflict} test={skill.test} status={skill.status}"
+            f"conflict={skill.conflict} test={skill.test} "
+            f"trust_state={trust_state_label(check_skill_trust_state(skill))} status={skill.status}"
         )
     return "\n".join(lines)
 
@@ -101,6 +110,7 @@ def _single_payload(report: CheckSkillReport) -> dict[str, Any]:
         "conflict": report.conflict,
         "test": report.test,
         "status": report.status,
+        "trust_state": trust_state_label(check_skill_trust_state(report)),
         "summary": report.summary,
         "result": report.result,
     }

--- a/skill_guard/commands/test.py
+++ b/skill_guard/commands/test.py
@@ -16,6 +16,7 @@ from skill_guard.engine.agent_runner import (
 )
 from skill_guard.models import HealthCheckTimeoutError, HookError, SkillParseError
 from skill_guard.output.json_out import format_as_json
+from skill_guard.output.semantics import test_trust_state, trust_state_label
 from skill_guard.output.workspace import write_workspace_setup_failure
 from skill_guard.parser import parse_skill
 
@@ -52,6 +53,7 @@ def _emit(payload: dict[str, Any], output_format: str) -> None:
             f"- pass_rate: {payload['pass_rate']:.2%}",
             f"- avg_latency_ms: {payload['avg_latency_ms']:.1f}",
             f"- status: {'passed' if payload['passed'] else 'failed'}",
+            f"- trust_state: {payload['trust_state']}",
         ]
         typer.echo("\n".join(lines))
         return
@@ -60,7 +62,8 @@ def _emit(payload: dict[str, Any], output_format: str) -> None:
         f"skill={payload['skill_name']} endpoint={payload['endpoint']} "
         f"passed={payload['passed_tests']}/{payload['total_tests']} "
         f"pass_rate={payload['pass_rate']:.2%} avg_latency_ms={payload['avg_latency_ms']:.1f} "
-        f"status={'passed' if payload['passed'] else 'failed'}"
+        f"status={'passed' if payload['passed'] else 'failed'} "
+        f"trust_state={payload['trust_state']}"
     )
     for test_result in payload["results"]:
         status = "PASS" if test_result["passed"] else "FAIL"
@@ -92,6 +95,7 @@ def _emit_baseline(payload: dict[str, Any], output_format: str) -> None:
             f"- pass_rate_delta: {payload['pass_rate_delta']:.2%}",
             f"- improved/regressed/unchanged: {payload['improved_tests']}/{payload['regressed_tests']}/{payload['unchanged_tests']}",
             f"- status: {'passed' if payload['passed'] else 'failed'}",
+            f"- trust_state: {payload['trust_state']}",
         ]
         typer.echo("\n".join(lines))
         return
@@ -101,7 +105,8 @@ def _emit_baseline(payload: dict[str, Any], output_format: str) -> None:
         f"with_skill={payload['with_skill']['passed_tests']}/{payload['with_skill']['total_tests']} "
         f"baseline={payload['baseline']['passed_tests']}/{payload['baseline']['total_tests']} "
         f"pass_rate_delta={payload['pass_rate_delta']:.2%} "
-        f"status={'passed' if payload['passed'] else 'failed'}"
+        f"status={'passed' if payload['passed'] else 'failed'} "
+        f"trust_state={payload['trust_state']}"
     )
     for comparison in payload["comparisons"]:
         with_status = "PASS" if comparison["with_skill_passed"] else "FAIL"
@@ -178,8 +183,10 @@ def test_cmd(
 
     payload = result.model_dump(mode="json")
     if run_baseline:
+        payload["trust_state"] = trust_state_label(test_trust_state(result))
         _emit_baseline(payload, format)
     else:
+        payload["trust_state"] = trust_state_label(test_trust_state(result))
         _emit(payload, format)
 
     if run_baseline:

--- a/skill_guard/output/json_out.py
+++ b/skill_guard/output/json_out.py
@@ -8,6 +8,23 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from skill_guard.models import (
+    AgentTestComparisonResult,
+    AgentTestResult,
+    CheckRunReport,
+    ConflictResult,
+    SecurityResult,
+    ValidationResult,
+)
+from skill_guard.output.semantics import (
+    check_run_trust_state,
+    check_skill_trust_state,
+    conflict_trust_state,
+    security_trust_state,
+    test_trust_state,
+    validation_trust_state,
+)
+
 
 def format_as_json(result: Any, command: str | None = None) -> str:
     payload = {
@@ -16,8 +33,27 @@ def format_as_json(result: Any, command: str | None = None) -> str:
     }
 
     if isinstance(result, BaseModel):
-        payload["result"] = result.model_dump(mode="json")
+        payload["result"] = _serialize_with_trust_state(result)
     else:
         payload["result"] = result
 
     return json.dumps(payload, indent=2, default=str)
+
+
+def _serialize_with_trust_state(result: BaseModel) -> dict[str, Any]:
+    payload = result.model_dump(mode="json")
+
+    if isinstance(result, ValidationResult):
+        payload["trust_state"] = validation_trust_state(result)
+    elif isinstance(result, SecurityResult):
+        payload["trust_state"] = security_trust_state(result)
+    elif isinstance(result, ConflictResult):
+        payload["trust_state"] = conflict_trust_state(result)
+    elif isinstance(result, AgentTestResult | AgentTestComparisonResult):
+        payload["trust_state"] = test_trust_state(result)
+    elif isinstance(result, CheckRunReport):
+        payload["trust_state"] = check_run_trust_state(result)
+        for dumped_skill, skill in zip(payload["skills"], result.skills, strict=False):
+            dumped_skill["trust_state"] = check_skill_trust_state(skill)
+
+    return payload

--- a/skill_guard/output/markdown.py
+++ b/skill_guard/output/markdown.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from typing import Any
 
 from skill_guard.models import CheckRunReport, ConflictResult, SecurityResult, ValidationResult
+from skill_guard.output.semantics import (
+    check_run_trust_state,
+    check_skill_trust_state,
+    conflict_trust_state,
+    security_trust_state,
+    trust_state_label,
+    validation_trust_state,
+)
 
 
 def format_as_markdown(result: Any, command: str = "") -> str:
@@ -39,7 +47,8 @@ def _validation_md(result: ValidationResult) -> str:
         + "\n".join(base_rows)
         + f"\n\n**Score:** {result.score}/100 (Grade {result.grade}) | "
         f"Blockers: {result.blockers} | Warnings: {result.warnings} | "
-        f"Status: {_validation_status_label(result)}\n"
+        f"Status: {_validation_status_label(result)} | "
+        f"Trust state: {trust_state_label(validation_trust_state(result))}\n"
     )
     if spec_rows:
         rendered += (
@@ -67,7 +76,8 @@ def _security_md(result: SecurityResult) -> str:
         + (
             f"\n\n**Critical:** {result.critical_count} | **High:** {result.high_count} | "
             f"**Medium:** {result.medium_count} | **Low:** {result.low_count} | "
-            f"**Status:** {_security_status_label(result)}"
+            f"**Status:** {_security_status_label(result)} | "
+            f"**Trust state:** {trust_state_label(security_trust_state(result))}"
         )
     )
 
@@ -96,7 +106,8 @@ def _conflict_md(result: ConflictResult) -> str:
         + (
             f"\n\n**High conflicts:** {result.high_conflicts} | "
             f"**Medium conflicts:** {result.medium_conflicts} | "
-            f"**Status:** {_conflict_status_label(result)}"
+            f"**Status:** {_conflict_status_label(result)} | "
+            f"**Trust state:** {trust_state_label(conflict_trust_state(result))}"
         )
     )
 
@@ -106,7 +117,8 @@ def _check_run_md(result: CheckRunReport) -> str:
     for skill in result.skills:
         rows.append(
             f"| {skill.skill_name} | {skill.target_status} | {skill.validation} | "
-            f"{skill.security} | {skill.conflict} | {skill.test} | {skill.status} |"
+            f"{skill.security} | {skill.conflict} | {skill.test} | "
+            f"{trust_state_label(check_skill_trust_state(skill))} | {skill.status} |"
         )
 
     if not rows:
@@ -124,9 +136,10 @@ def _check_run_md(result: CheckRunReport) -> str:
         f"- warnings: {result.warnings}\n"
         f"- failed: {result.failed}\n"
         f"- status: {result.status}\n"
+        f"- trust_state: {trust_state_label(check_run_trust_state(result))}\n"
         f"- summary: {result.summary}\n\n"
-        "| Skill | Change | Validation | Security | Conflict | Test | Status |\n"
-        "|---|---|---|---|---|---|---|\n" + "\n".join(rows)
+        "| Skill | Change | Validation | Security | Conflict | Test | Trust state | Status |\n"
+        "|---|---|---|---|---|---|---|---|\n" + "\n".join(rows)
     )
 
 
@@ -140,6 +153,8 @@ def _validation_status_label(result: ValidationResult) -> str:
 
 def _security_status_label(result: SecurityResult) -> str:
     if result.passed:
+        if any(finding.suppressed for finding in result.findings):
+            return "intentional exceptions present"
         return "no blocking findings"
     return "blocking findings present"
 

--- a/skill_guard/output/semantics.py
+++ b/skill_guard/output/semantics.py
@@ -1,0 +1,100 @@
+"""Shared trust-state semantics for command outputs."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from skill_guard.models import (
+    AgentTestComparisonResult,
+    AgentTestResult,
+    CheckRunReport,
+    CheckSkillReport,
+    ConflictResult,
+    SecurityResult,
+    ValidationResult,
+)
+
+TrustState = Literal["clean", "warning", "exception", "needs_review", "blocking"]
+
+
+def validation_trust_state(result: ValidationResult) -> TrustState:
+    if result.blockers > 0:
+        return "blocking"
+    if result.warnings > 0:
+        return "warning"
+    return "clean"
+
+
+def security_trust_state(result: SecurityResult) -> TrustState:
+    unsuppressed = [finding for finding in result.findings if not finding.suppressed]
+    suppressed = [finding for finding in result.findings if finding.suppressed]
+    if unsuppressed and not result.passed:
+        return "blocking"
+    if suppressed:
+        return "exception"
+    if unsuppressed:
+        return "warning"
+    return "clean"
+
+
+def conflict_trust_state(result: ConflictResult) -> TrustState:
+    if result.name_collision or result.high_conflicts > 0:
+        return "blocking"
+    if result.medium_conflicts > 0:
+        return "warning"
+    return "clean"
+
+
+def test_trust_state(result: AgentTestResult | AgentTestComparisonResult) -> TrustState:
+    test_result = result.with_skill if isinstance(result, AgentTestComparisonResult) else result
+    if not test_result.passed:
+        return "blocking"
+    if any(test.needs_review for test in test_result.results):
+        return "needs_review"
+    return "clean"
+
+
+def check_skill_trust_state(skill: CheckSkillReport) -> TrustState:
+    if skill.status == "failed":
+        return "blocking"
+
+    security = skill.result.get("security") or {}
+    findings = security.get("findings") or []
+    if findings and any(finding.get("suppressed") for finding in findings):
+        return "exception"
+
+    test_result = skill.result.get("test") or {}
+    if any(test.get("needs_review") for test in test_result.get("results", [])):
+        return "needs_review"
+
+    if skill.validation == "warning" or skill.conflict == "warning" or skill.test == "warning":
+        return "warning"
+
+    return "clean"
+
+
+def check_run_trust_state(report: CheckRunReport) -> TrustState:
+    states = [check_skill_trust_state(skill) for skill in report.skills]
+    if not states:
+        return "clean"
+    return max(states, key=_trust_state_rank)
+
+
+def trust_state_label(state: TrustState) -> str:
+    return {
+        "clean": "clean",
+        "warning": "warning",
+        "exception": "intentional exception",
+        "needs_review": "needs review",
+        "blocking": "blocking",
+    }[state]
+
+
+def _trust_state_rank(state: TrustState) -> int:
+    return {
+        "clean": 0,
+        "warning": 1,
+        "exception": 2,
+        "needs_review": 3,
+        "blocking": 4,
+    }[state]

--- a/skill_guard/output/text.py
+++ b/skill_guard/output/text.py
@@ -6,6 +6,12 @@ from rich.console import Console
 from rich.table import Table
 
 from skill_guard.models import ConflictResult, SecurityResult, ValidationResult
+from skill_guard.output.semantics import (
+    conflict_trust_state,
+    security_trust_state,
+    trust_state_label,
+    validation_trust_state,
+)
 
 console = Console()
 
@@ -35,7 +41,8 @@ def format_validation_result(
     console.print(
         f"Score: {result.score}/100 | Grade: {result.grade} | "
         f"Blockers: {result.blockers} | Warnings: {result.warnings} | "
-        f"Status: {_validation_status_label(result)}"
+        f"Status: {_validation_status_label(result)} | "
+        f"Trust state: {trust_state_label(validation_trust_state(result))}"
     )
 
 
@@ -79,7 +86,8 @@ def format_security_result(result: SecurityResult, quiet: bool = False) -> None:
     console.print(
         f"Critical: {result.critical_count} | High: {result.high_count} | "
         f"Medium: {result.medium_count} | Low: {result.low_count} | "
-        f"Status: {_security_status_label(result)}"
+        f"Status: {_security_status_label(result)} | "
+        f"Trust state: {trust_state_label(security_trust_state(result))}"
     )
 
 
@@ -106,7 +114,8 @@ def format_conflict_result(result: ConflictResult, quiet: bool = False) -> None:
     console.print(table)
     console.print(
         f"High conflicts: {result.high_conflicts} | Medium conflicts: {result.medium_conflicts} | "
-        f"Status: {_conflict_status_label(result)}"
+        f"Status: {_conflict_status_label(result)} | "
+        f"Trust state: {trust_state_label(conflict_trust_state(result))}"
     )
 
 
@@ -120,6 +129,8 @@ def _validation_status_label(result: ValidationResult) -> str:
 
 def _security_status_label(result: SecurityResult) -> str:
     if result.passed:
+        if any(finding.suppressed for finding in result.findings):
+            return "intentional exceptions present"
         return "no blocking findings"
     return "blocking findings present"
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -27,7 +27,9 @@ def test_json_output_roundtrip():
         blockers=0,
     )
     out = format_as_json(val, command="validate")
-    assert '"command": "validate"' in out
+    payload = json.loads(out)
+    assert payload["command"] == "validate"
+    assert payload["result"]["trust_state"] == "clean"
 
 
 def test_markdown_output():
@@ -121,7 +123,8 @@ def test_markdown_output_supports_aggregate_check_report():
     md = format_as_markdown(report, command="check")
 
     assert "## skill-guard check" in md
-    assert "| alpha | modified | passed | passed | passed | skipped | passed |" in md
+    assert "trust_state: clean" in md
+    assert "| alpha | modified | passed | passed | passed | skipped | clean | passed |" in md
 
 
 def test_markdown_output_includes_remediation_and_status_summaries():
@@ -187,8 +190,41 @@ def test_markdown_output_includes_remediation_and_status_summaries():
     conflict_md = format_as_markdown(conflict, command="conflict")
 
     assert "→ Create evals/evals.json." in validation_md
-    assert "Status: warnings only (non-blocking by default)" in validation_md
+    assert "Status: warnings only (non-blocking by default) | Trust state: warning" in validation_md
     assert "secure.allow_external_urls_in_scripts: true when intentional" in security_md
-    assert "Status:** no blocking findings" in security_md
+    assert "**Trust state:** warning" in security_md
     assert "Add conflict_ignore in SKILL.md if this overlap is intentional" in conflict_md
-    assert "Status:** warnings only" in conflict_md
+    assert "**Trust state:** warning" in conflict_md
+
+
+def test_json_output_adds_check_trust_states():
+    report = CheckRunReport(
+        mode="changed",
+        target_root=Path("/tmp/skills"),
+        against=Path("/tmp/skills"),
+        total_skills=1,
+        checked_skills=1,
+        skipped_skills=0,
+        passed=0,
+        warnings=1,
+        failed=0,
+        status="warning",
+        summary="1 skill checked: warnings only.",
+        skills=[
+            CheckSkillReport(
+                skill_name="alpha",
+                skill_path=Path("/tmp/skills/alpha"),
+                target_status="modified",
+                validation="warning",
+                security="passed",
+                conflict="passed",
+                test="skipped",
+                status="warning",
+                summary="Warnings only.",
+            )
+        ],
+    )
+
+    payload = json.loads(format_as_json(report, command="check"))
+    assert payload["result"]["trust_state"] == "warning"
+    assert payload["result"]["skills"][0]["trust_state"] == "warning"

--- a/tests/unit/test_output_text.py
+++ b/tests/unit/test_output_text.py
@@ -122,5 +122,7 @@ def test_text_formatters_include_status_labels(capsys) -> None:
 
     output = capsys.readouterr().out
     assert "non-blocking by default" in output
+    assert "Trust state: warning" in output
     assert "Status: no blocking findings" in output
+    assert "Trust state: clean" in output
     assert "Status: warnings only" in output


### PR DESCRIPTION
## Summary
- add a shared trust-state layer (`clean`, `warning`, `exception`, `needs_review`, `blocking`) on top of the existing CI status contract
- thread trust-state output through check, test, JSON, markdown, and text renderers
- document the trust-state contract in README and CI docs

## Testing
- TMPDIR=$PWD/.tmp pytest --no-cov -q tests/unit/test_output.py tests/unit/test_output_text.py tests/unit/test_check_cmd.py tests/unit/test_test_cmd.py tests/unit/test_cli.py

Closes #126